### PR TITLE
Add world-based sound playback & getLong

### DIFF
--- a/DrcomoCoreLib/JavaDocs/SoundManager-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/SoundManager-JavaDoc.md
@@ -110,5 +110,52 @@
           * `player` (`Player`): 目标玩家。
           * `soundString` (`String`): 格式为 `"SoundName-Volume-Pitch"` 的字符串，例如 `"UI_BUTTON_CLICK-1.0-1.0"`。
 
+  * #### `playSoundFromStringInRadius(Location center, String soundString, double radius)`
+
+      * **返回类型:** `void`
+      * **功能描述:** 在指定位置一定半径内，根据字符串定义播放音效。
+      * **参数说明:**
+          * `center` (`Location`): 中心位置。
+          * `soundString` (`String`): `"SoundName-Volume-Pitch"` 格式的字符串。
+          * `radius` (`double`): 半径（方块数）。
+
+  * #### `playSound(String worldName, double x, double y, double z, String key)`
+
+      * **返回类型:** `void`
+      * **功能描述:** 通过世界名称和坐标在指定位置播放预定义音效。
+      * **参数说明:**
+          * `worldName` (`String`): 世界名称。
+          * `x`, `y`, `z` (`double`): 坐标。
+          * `key` (`String`): 音效键。
+
+  * #### `playSoundInRadius(String worldName, double x, double y, double z, String key, double radius)`
+
+      * **返回类型:** `void`
+      * **功能描述:** 通过世界名称和坐标，在半径范围内播放预定义音效。
+      * **参数说明:**
+          * `worldName` (`String`): 世界名称。
+          * `x`, `y`, `z` (`double`): 坐标。
+          * `key` (`String`): 音效键。
+          * `radius` (`double`): 半径（方块数）。
+
+  * #### `playSoundFromString(String worldName, double x, double y, double z, String soundString)`
+
+      * **返回类型:** `void`
+      * **功能描述:** 通过世界名称和坐标，根据字符串定义播放音效。
+      * **参数说明:**
+          * `worldName` (`String`): 世界名称。
+          * `x`, `y`, `z` (`double`): 坐标。
+          * `soundString` (`String`): `"SoundName-Volume-Pitch"` 格式的字符串。
+
+  * #### `playSoundFromStringInRadius(String worldName, double x, double y, double z, String soundString, double radius)`
+
+      * **返回类型:** `void`
+      * **功能描述:** 通过世界名称和坐标，在半径范围内根据字符串定义播放音效。
+      * **参数说明:**
+          * `worldName` (`String`): 世界名称。
+          * `x`, `y`, `z` (`double`): 坐标。
+          * `soundString` (`String`): `"SoundName-Volume-Pitch"` 格式的字符串。
+          * `radius` (`double`): 半径（方块数）。
+
 -----
 

--- a/DrcomoCoreLib/JavaDocs/YamlUtil-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/YamlUtil-JavaDoc.md
@@ -92,9 +92,9 @@
           * `path` (`String`): YAML 中的路径，例如 `"database.host"`。
           * `def` (`String`): 默认值。
 
-  * #### `getInt`, `getBoolean`, `getDouble`, `getStringList`
+  * #### `getInt`, `getBoolean`, `getDouble`, `getLong`, `getStringList`
 
-      * **功能描述:** 与 `getString` 类似，分别用于读取整数、布尔值、双精度浮点数和字符串列表，都支持写入默认值。
+      * **功能描述:** 与 `getString` 类似，分别用于读取整数、布尔值、双精度浮点数、长整数和字符串列表，都支持写入默认值。
 
   * #### `setValue(String fileName, String path, Object value)`
 

--- a/src/main/java/cn/drcomo/corelib/config/YamlUtil.java
+++ b/src/main/java/cn/drcomo/corelib/config/YamlUtil.java
@@ -202,6 +202,15 @@ public class YamlUtil {
     }
 
     /**
+     * 从配置获取长整数，若无则写入默认并保存
+     */
+    public long getLong(String fileName, String path, long def) {
+        YamlConfiguration cfg = getConfig(fileName);
+        setDefaultIfAbsent(cfg, fileName, path, def);
+        return cfg.getLong(path, def);
+    }
+
+    /**
      * 从配置获取字符串列表，若无则写入默认并保存
      */
     public List<String> getStringList(String fileName, String path, List<String> def) {

--- a/src/main/java/cn/drcomo/corelib/sound/SoundManager.java
+++ b/src/main/java/cn/drcomo/corelib/sound/SoundManager.java
@@ -200,6 +200,85 @@ public class SoundManager {
         }
     }
 
+    /**
+     * 根据世界名称和坐标，在指定位置播放音效。
+     *
+     * @param worldName 世界名称
+     * @param x         X 坐标
+     * @param y         Y 坐标
+     * @param z         Z 坐标
+     * @param key       音效键
+     */
+    public void playSound(String worldName, double x, double y, double z, String key) {
+        World world = plugin.getServer().getWorld(worldName);
+        if (world == null) {
+            logger.warn("找不到世界: " + worldName);
+            return;
+        }
+        playSoundAtLocation(new Location(world, x, y, z), key);
+    }
+
+    /**
+     * 根据世界名称和坐标，在半径范围内播放音效。
+     *
+     * @param worldName 世界名称
+     * @param x         X 坐标
+     * @param y         Y 坐标
+     * @param z         Z 坐标
+     * @param key       音效键
+     * @param radius    半径（方块数）
+     */
+    public void playSoundInRadius(String worldName, double x, double y, double z, String key, double radius) {
+        World world = plugin.getServer().getWorld(worldName);
+        if (world == null) {
+            logger.warn("找不到世界: " + worldName);
+            return;
+        }
+        playSoundInRadius(new Location(world, x, y, z), key, radius);
+    }
+
+    /**
+     * 根据世界名称和坐标，直接根据字符串定义播放音效。
+     *
+     * @param worldName   世界名称
+     * @param x           X 坐标
+     * @param y           Y 坐标
+     * @param z           Z 坐标
+     * @param soundString 音效字符串，格式 "name-volume-pitch"
+     */
+    public void playSoundFromString(String worldName, double x, double y, double z, String soundString) {
+        World world = plugin.getServer().getWorld(worldName);
+        if (world == null) {
+            logger.warn("找不到世界: " + worldName);
+            return;
+        }
+        SoundEffectData data = parseSoundString(soundString);
+        if (data != null) {
+            playToWorld(new Location(world, x, y, z), data);
+        } else if (warnOnMissingKeys) {
+            logger.warn("音效字符串格式无效: " + soundString);
+        }
+    }
+
+    /**
+     * 根据世界名称和坐标，在半径范围内播放字符串定义的音效。
+     *
+     * @param worldName   世界名称
+     * @param x           X 坐标
+     * @param y           Y 坐标
+     * @param z           Z 坐标
+     * @param soundString 音效字符串，格式 "name-volume-pitch"
+     * @param radius      半径（方块数）
+     */
+    public void playSoundFromStringInRadius(String worldName, double x, double y, double z, String soundString, double radius) {
+        World world = plugin.getServer().getWorld(worldName);
+        if (world == null) {
+            logger.warn("找不到世界: " + worldName);
+            return;
+        }
+        playSoundFromStringInRadius(new Location(world, x, y, z), soundString, radius);
+    }
+
     // ===== 私有辅助方法 =====
 
     /**


### PR DESCRIPTION
## Summary
- enhance `SoundManager` with world-name overloads for playing sounds
- document the new `SoundManager` APIs in its JavaDoc
- add `getLong` convenience method to `YamlUtil`
- document `getLong` in `YamlUtil` JavaDoc

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fa2eb5b288330ae901ab3c960985d