### PR TITLE
Implement bulk YAML loading

### DIFF
--- a/DrcomoCoreLib/JavaDocs/config/YamlUtil-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/config/YamlUtil-JavaDoc.md
@@ -78,6 +78,14 @@
       * **参数说明:**
           * `fileName` (`String`): 文件名，**不**包含 `.yml` 后缀。
 
+  * #### `loadAllConfigsInFolder(String folderPath)`
+
+      * **返回类型:** `Map<String, YamlConfiguration>`
+      * **功能描述:** 扫描指定目录下的所有 `.yml` 文件并逐个加载，返回的映射以文件名为键，`YamlConfiguration` 为值，同时写入内部缓存。
+      * **参数说明:**
+          * `folderPath` (`String`): 相对于插件数据文件夹的目录路径。
+      * **返回值:** `Map<文件名, 配置对象>`
+
   * #### `reloadConfig(String fileName)`
 
       * **返回类型:** `void`

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ public class MyAwesomePlugin extends JavaPlugin {
 本库提供以下核心工具类，所有类都需通过 `new` 关键字实例化使用：
 
   * `DebugUtil`: 分级日志工具。
-  * `YamlUtil`: YAML 配置文件管理器。
+  * `YamlUtil`: YAML 配置文件管理器，可一次性加载目录内的多份配置。
   * `MessageService`: 支持多语言和 PlaceholderAPI 的消息管理器。
   * `SoundManager`: 音效管理器。
   * `NBTUtil`: 物品 NBT 数据操作工具。

--- a/src/main/java/cn/drcomo/corelib/config/YamlUtil.java
+++ b/src/main/java/cn/drcomo/corelib/config/YamlUtil.java
@@ -147,6 +147,36 @@ public class YamlUtil {
     }
 
     /**
+     * 扫描指定目录下的所有 {@code .yml} 文件并全部加载。
+     * 加载的配置会放入内部缓存，以文件名（不含副档名）为键。
+     *
+     * @param folderPath 相对于插件数据文件夹的目录路径
+     * @return 以文件名为键、配置对象为值的映射
+     */
+    public Map<String, YamlConfiguration> loadAllConfigsInFolder(String folderPath) {
+        Map<String, YamlConfiguration> map = new HashMap<>();
+        File dir = new File(plugin.getDataFolder(), folderPath);
+        if (!dir.exists() || !dir.isDirectory()) {
+            logger.warn("目录不存在: " + dir.getPath());
+            return map;
+        }
+        File[] files = dir.listFiles((d, name) -> name.endsWith(".yml"));
+        if (files == null) return map;
+        for (File file : files) {
+            String name = file.getName().replaceFirst("\\.yml$", "");
+            try {
+                YamlConfiguration cfg = YamlConfiguration.loadConfiguration(file);
+                configs.put(name, cfg);
+                map.put(name, cfg);
+                logger.debug("Loaded config: " + file.getPath());
+            } catch (Exception e) {
+                logger.error("加载配置失败: " + file.getPath(), e);
+            }
+        }
+        return map;
+    }
+
+    /**
      * 重载配置文件
      *
      * @param fileName 文件名（不含 .yml）


### PR DESCRIPTION
## Summary
- add `loadAllConfigsInFolder` in `YamlUtil` to read every `.yml` file in a directory
- document the new method in YamlUtil JavaDoc
- mention this feature briefly in README

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b503b2c18833092c689cb8552e772