### PR TITLE
Add type-safe YAML access

### DIFF
--- a/DrcomoCoreLib/JavaDocs/config/YamlUtil-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/config/YamlUtil-JavaDoc.md
@@ -144,3 +144,12 @@
       * **参数说明:**
           * `fileName` (`String`): 文件名。
           * `path` (`String`): 路径。
+
+  * #### `getValue(String path, Class<T> type, T defaultValue)`
+
+      * **返回类型:** `<T>`
+      * **功能描述:** 从默认 `config.yml` 中按给定类型读取值。若路径不存在或类型不符，会写入并返回 `defaultValue`。
+      * **参数说明:**
+          * `path` (`String`): 配置路径。
+          * `type` (`Class<T>`): 期望的类型，例如 `String.class`。
+          * `defaultValue` (`T`): 默认值。

--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ public class MyAwesomePlugin extends JavaPlugin {
         );
         mySoundManager.loadSounds(); // 手动加载音效
 
+        // 4. 使用类型安全的方式读取配置
+        boolean autoSave = myYamlUtil.getValue("settings.auto-save", Boolean.class, true);
+        if (autoSave) {
+            myLogger.info("自动保存已启用");
+        }
+
         myLogger.info("我的插件已成功加载，并配置好了核心库工具！");
     }
 }

--- a/src/main/java/cn/drcomo/corelib/config/YamlUtil.java
+++ b/src/main/java/cn/drcomo/corelib/config/YamlUtil.java
@@ -29,6 +29,8 @@ public class YamlUtil {
     private final DebugUtil logger;
     private final Map<String, YamlConfiguration> configs = new HashMap<>();
     private final String jarPath;
+    /** 默认配置文件名 */
+    private static final String DEFAULT_FILE = "config";
 
     /**
      * 构造函数
@@ -259,6 +261,27 @@ public class YamlUtil {
         ConfigurationSection sec = getConfig(fileName).getConfigurationSection(path);
         logger.debug("Section retrieved: " + path + " exists=" + (sec != null));
         return sec;
+    }
+
+    /**
+     * 从默认 config.yml 中以类型安全的方式读取配置。
+     * 若路径不存在或类型不符，则写入并返回默认值。
+     *
+     * @param path         配置路径
+     * @param type         期望的类型，例如 {@code String.class}
+     * @param defaultValue 默认值
+     * @return 读取到的值
+     */
+    public <T> T getValue(String path, Class<T> type, T defaultValue) {
+        YamlConfiguration cfg = getConfig(DEFAULT_FILE);
+        Object val = cfg.get(path);
+        if (val == null || !type.isInstance(val)) {
+            cfg.set(path, defaultValue);
+            saveConfig(DEFAULT_FILE);
+            logger.debug("Set typed default: " + path + " = " + defaultValue);
+            return defaultValue;
+        }
+        return type.cast(val);
     }
 
     /**


### PR DESCRIPTION
## Summary
- add DEFAULT_FILE constant and new `getValue` method in `YamlUtil`
- document the new API
- show type-safe access example in README

## Testing
- `apt-get update` *(fails: repository 403 Forbidden)*
- `javac -Xlint:none @sources.txt` *(fails: missing Bukkit and other deps)*

------
https://chatgpt.com/codex/tasks/task_e_687b503b1c60833081983a6448ca39d5