### PR TITLE
Add public APIs for action bar and titles

### DIFF
--- a/DrcomoCoreLib/JavaDocs/message/MessageService-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/message/MessageService-JavaDoc.md
@@ -261,6 +261,15 @@
           * `player` (`Player`): 目标玩家。
           * `messages` (`List<String>`): 已经解析和处理好颜色的消息列表。
 
+  * #### `sendActionBar(Player player, String key, Map<String, String> custom)`
+
+      * **返回类型:** `void`
+      * **功能描述:** 解析并通过 ActionBar 向玩家发送单行消息。
+      * **参数说明:**
+          * `player` (`Player`): 目标玩家。
+          * `key` (`String`): 消息键。
+          * `custom` (`Map<String, String>`): 自定义占位符。
+
   * #### `sendStagedActionBar(Player player, List<String> messages)`
 
       * **返回类型:** `void`
@@ -268,6 +277,16 @@
       * **参数说明:**
           * `player` (`Player`): 目标玩家。
           * `messages` (`List<String>`): 要在 ActionBar 上显示的消息列表。
+
+  * #### `sendTitle(Player player, String titleKey, String subKey, Map<String, String> custom)`
+
+      * **返回类型:** `void`
+      * **功能描述:** 解析并向玩家发送标题和副标题。
+      * **参数说明:**
+          * `player` (`Player`): 目标玩家。
+          * `titleKey` (`String`): 主标题的消息键。
+          * `subKey` (`String`): 副标题的消息键。
+          * `custom` (`Map<String, String>`): 自定义占位符。
 
   * #### `sendStagedTitle(Player player, List<String> titles, List<String> subtitles)`
 

--- a/src/main/java/cn/drcomo/corelib/message/MessageService.java
+++ b/src/main/java/cn/drcomo/corelib/message/MessageService.java
@@ -246,6 +246,19 @@ public class MessageService {
         sendColorizedList(player, messages);
     }
 
+    /**
+     * 解析并向玩家发送一条 ActionBar 消息。
+     *
+     * @param player 目标玩家
+     * @param key    消息键
+     * @param custom 自定义占位符
+     */
+    public void sendActionBar(Player player, String key, Map<String, String> custom) {
+        String msg = parse(key, player, custom);
+        if (msg != null) sendActionBar(player, msg);
+        else logger.warn("发送 ActionBar 失败，键: " + key);
+    }
+
     public void sendStagedActionBar(Player player, List<String> messages) {
         for (String msg : messages) sendActionBar(player, msg);
     }
@@ -253,6 +266,21 @@ public class MessageService {
     public void sendStagedTitle(Player player, List<String> titles, List<String> subtitles) {
         int n = Math.min(titles.size(), subtitles.size());
         for (int i = 0; i < n; i++) sendTitle(player, titles.get(i), subtitles.get(i));
+    }
+
+    /**
+     * 解析并向玩家发送 Title 与 SubTitle。
+     *
+     * @param player   目标玩家
+     * @param titleKey 主标题键
+     * @param subKey   副标题键
+     * @param custom   自定义占位符
+     */
+    public void sendTitle(Player player, String titleKey, String subKey, Map<String, String> custom) {
+        String title = parse(titleKey, player, custom);
+        String sub = parse(subKey, player, custom);
+        if (title != null && sub != null) sendTitle(player, title, sub);
+        else logger.warn("发送 Title 失败，键: " + titleKey + " / " + subKey);
     }
 
     // === 上下文消息管理 ===


### PR DESCRIPTION
## Summary
- add `sendActionBar` and `sendTitle` methods to `MessageService`
- document new APIs in `MessageService` docs

## Testing
- `apt-get update` *(fails: repository signed errors)*

------
https://chatgpt.com/codex/tasks/task_e_687b5ac5ad2883308603bed059cff60e