### PR TITLE
Add HttpUtil utility

### DIFF
--- a/DrcomoCoreLib/JavaDocs/net/HttpUtil-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/net/HttpUtil-JavaDoc.md
@@ -1,0 +1,37 @@
+### `HttpUtil.java`
+
+**1. 概述 (Overview)**
+
+  * **完整路径:** `cn.drcomo.corelib.net.HttpUtil`
+  * **核心职责:** 通过 Java 11 `HttpClient` 提供异步的 GET、POST 与文件上传功能。
+    构建器允许配置代理、超时时间以及失败重试次数，并将网络异常记录到 `DebugUtil`。
+
+**2. 如何实例化 (Initialization)**
+
+  * **核心思想:** `HttpUtil` 通过 `HttpUtil.newBuilder()` 创建。必须注入 `DebugUtil`
+    才能输出网络日志。其余配置项可按需设定。
+  * **代码示例:**
+    ```java
+    DebugUtil logger = new DebugUtil(myPlugin, DebugUtil.LogLevel.INFO);
+
+    HttpUtil http = HttpUtil.newBuilder()
+            .logger(logger)
+            .timeout(Duration.ofSeconds(5))
+            .retries(2)
+            .build();
+    ```
+
+**3. 常用方法 (API)**
+
+  * #### `CompletableFuture<String> get(String url, Map<String,String> headers)`
+
+      * **功能描述:** 以 GET 方式请求指定 URL，返回响应文本。
+  * #### `CompletableFuture<String> post(String url, String body, Map<String,String> headers)`
+
+      * **功能描述:** 以 POST 方式发送字符串正文，并返回响应文本。
+  * #### `CompletableFuture<String> upload(String url, Path path, Map<String,String> headers)`
+
+      * **功能描述:** 将文件上传到指定地址，返回响应文本。
+
+所有方法均在出现网络异常或超时后写入 `DebugUtil`，并在达到设置的最大重试次数后将异常
+通过 `CompletableFuture` 传递给调用方。

--- a/README.md
+++ b/README.md
@@ -117,7 +117,18 @@ public class MyAwesomePlugin extends JavaPlugin {
   * `NBTUtil`: 物品 NBT 数据操作工具。
   * `PlaceholderAPIUtil`: PlaceholderAPI 占位符注册与解析工具。
   * `EconomyProvider`: 经济插件（Vault, PlayerPoints）的统一接口。
+  * `HttpUtil`: 异步 HTTP 请求工具，可配置代理、超时和重试。
   * ... 以及其他位于 `cn.drcomo.corelib` 包下的工具。
+
+### HttpUtil 使用时机
+
+在插件需要访问外部接口或上传数据时，可使用 `HttpUtil`。根据实际场景选择适当方法：
+
+* **get**：拉取远程配置或读取文本资源。
+* **post**：提交 JSON 或表单等数据，并处理返回值。
+* **upload**：向服务器上传文件。
+
+所有调用均返回 `CompletableFuture<String>`，可在回调中异步处理结果或异常。
 
 ### **优化点分析：**
 

--- a/src/main/java/cn/drcomo/corelib/net/HttpUtil.java
+++ b/src/main/java/cn/drcomo/corelib/net/HttpUtil.java
@@ -1,0 +1,169 @@
+package cn.drcomo.corelib.net;
+
+import cn.drcomo.corelib.util.DebugUtil;
+
+import java.net.InetSocketAddress;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * HTTP 请求工具类，使用 Java 11 {@link HttpClient} 实现异步网络访问。
+ * <p>通过构建器配置代理、超时和重试次数。</p>
+ */
+public class HttpUtil {
+
+    private final DebugUtil logger;
+    private final HttpClient client;
+    private final Duration timeout;
+    private final int maxRetries;
+
+    private HttpUtil(DebugUtil logger, HttpClient client, Duration timeout, int maxRetries) {
+        this.logger = logger;
+        this.client = client;
+        this.timeout = timeout;
+        this.maxRetries = maxRetries;
+    }
+
+    /**
+     * 创建 Builder 用于配置 HttpUtil。
+     *
+     * @return Builder 实例
+     */
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    /**
+     * 发送 GET 请求。
+     *
+     * @param url     请求地址
+     * @param headers 请求头，可为空
+     * @return 异步响应字符串
+     */
+    public CompletableFuture<String> get(String url, Map<String, String> headers) {
+        HttpRequest.Builder req = HttpRequest.newBuilder(URI.create(url)).GET();
+        applyHeaders(req, headers);
+        return sendAsync(req.build(), 0);
+    }
+
+    /**
+     * 发送 POST 请求，Body 为字符串。
+     *
+     * @param url     请求地址
+     * @param body    请求体
+     * @param headers 请求头，可为空
+     * @return 异步响应字符串
+     */
+    public CompletableFuture<String> post(String url, String body, Map<String, String> headers) {
+        HttpRequest.Builder req = HttpRequest.newBuilder(URI.create(url))
+                .POST(HttpRequest.BodyPublishers.ofString(body));
+        applyHeaders(req, headers);
+        return sendAsync(req.build(), 0);
+    }
+
+    /**
+     * 上传文件。
+     *
+     * @param url     请求地址
+     * @param path    文件路径
+     * @param headers 请求头，可为空
+     * @return 异步响应字符串
+     */
+    public CompletableFuture<String> upload(String url, java.nio.file.Path path, Map<String, String> headers) {
+        HttpRequest.Builder req = HttpRequest.newBuilder(URI.create(url))
+                .POST(HttpRequest.BodyPublishers.ofFile(path));
+        applyHeaders(req, headers);
+        return sendAsync(req.build(), 0);
+    }
+
+    private void applyHeaders(HttpRequest.Builder builder, Map<String, String> headers) {
+        if (headers != null) {
+            headers.forEach(builder::header);
+        }
+        builder.timeout(timeout);
+    }
+
+    private CompletableFuture<String> sendAsync(HttpRequest request, int attempt) {
+        return client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .thenApply(HttpResponse::body)
+                .exceptionallyCompose(ex -> {
+                    logger.error("网络请求失败: " + ex.getMessage());
+                    if (attempt < maxRetries) {
+                        logger.warn("重试中... (" + (attempt + 1) + "/" + maxRetries + ")");
+                        return sendAsync(request, attempt + 1);
+                    }
+                    CompletableFuture<String> fail = new CompletableFuture<>();
+                    fail.completeExceptionally(ex);
+                    return fail;
+                });
+    }
+
+    /**
+     * Builder 用于构建 HttpUtil。
+     */
+    public static class Builder {
+        private DebugUtil logger;
+        private ProxySelector proxy;
+        private Duration timeout = Duration.ofSeconds(10);
+        private int retries = 0;
+
+        /**
+         * 设置日志工具。
+         */
+        public Builder logger(DebugUtil logger) {
+            this.logger = logger;
+            return this;
+        }
+
+        /**
+         * 设置 HTTP 代理。
+         *
+         * @param host 主机名
+         * @param port 端口
+         */
+        public Builder proxy(String host, int port) {
+            this.proxy = ProxySelector.of(new InetSocketAddress(host, port));
+            return this;
+        }
+
+        /**
+         * 设置超时时间。
+         *
+         * @param timeout 超时
+         */
+        public Builder timeout(Duration timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        /**
+         * 设置最大重试次数。
+         *
+         * @param retries 次数
+         */
+        public Builder retries(int retries) {
+            this.retries = Math.max(0, retries);
+            return this;
+        }
+
+        /**
+         * 构建 HttpUtil 实例。
+         *
+         * @return HttpUtil
+         */
+        public HttpUtil build() {
+            HttpClient.Builder cb = HttpClient.newBuilder();
+            if (proxy != null) {
+                cb.proxy(proxy);
+            }
+            HttpClient client = cb.build();
+            return new HttpUtil(logger, client, timeout, retries);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add HttpUtil with async GET/POST/upload methods and builder config
- document HttpUtil usage and API
- describe how to use HttpUtil in README

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ccd282d0883308f1e70e5e3840901