### PR TITLE
Add ConfigValidator

### DIFF
--- a/DrcomoCoreLib/JavaDocs/config/ConfigValidator-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/config/ConfigValidator-JavaDoc.md
@@ -1,0 +1,62 @@
+### `ConfigValidator.java`
+
+**1. 概述 (Overview)**
+
+  * **完整路径:** `cn.drcomo.corelib.config.ConfigValidator`
+  * **核心职责:** 一个通用的配置校验器，允许开发者以链式方式声明配置项的类型、是否必填以及自定义校验规则，最终给出校验结果。
+
+**2. 如何实例化 (Initialization)**
+
+  * **构造函数:** `public ConfigValidator(YamlUtil yamlUtil, DebugUtil logger)`
+  * **代码示例:**
+    ```java
+    YamlUtil yamlUtil = new YamlUtil(plugin, logger);
+    yamlUtil.loadConfig("config");
+    ConfigValidator validator = new ConfigValidator(yamlUtil, logger);
+    ```
+
+**3. 公共API方法 (Public API Methods)**
+
+  * #### `validateString(String path)`
+
+      * **返回类型:** `ValidatorBuilder`
+      * **功能描述:** 声明一个字符串类型的配置项，返回的 `ValidatorBuilder` 可继续设置 `required()` 或 `custom()` 约束。
+      * **参数说明:**
+          * `path` (`String`): 配置路径。
+
+  * #### `validateNumber(String path)`
+
+      * **返回类型:** `ValidatorBuilder`
+      * **功能描述:** 声明一个数字类型的配置项，允许校验整数或浮点数字符串。
+      * **参数说明:**
+          * `path` (`String`): 配置路径。
+
+  * #### `validateEnum(String path, Class<E> enumClass)`
+
+      * **返回类型:** `ValidatorBuilder`
+      * **功能描述:** 声明一个枚举类型的配置项，值将按不区分大小写的方式解析为指定枚举。
+      * **参数说明:**
+          * `path` (`String`): 配置路径。
+          * `enumClass` (`Class<E>`): 期望的枚举类型。
+
+  * #### `required()` *(ValidatorBuilder)*
+
+      * **返回类型:** `ValidatorBuilder`
+      * **功能描述:** 标记当前配置项为必填项，若缺失则校验失败。
+      * **参数说明:** 无。
+
+  * #### `custom(Predicate<Object> rule, String message)` *(ValidatorBuilder)*
+
+      * **返回类型:** `ValidatorBuilder`
+      * **功能描述:** 为当前配置项添加自定义校验规则，当 `rule.test(value)` 返回 `false` 时，校验失败并记录 `message`。
+      * **参数说明:**
+          * `rule` (`Predicate<Object>`): 自定义断言。
+          * `message` (`String`): 失败时的提示信息。
+
+  * #### `validate(Configuration config)`
+
+      * **返回类型:** `ValidationResult`
+      * **功能描述:** 针对给定的 `Configuration` 执行所有已声明的校验，并返回结果对象，包含是否通过及所有错误信息。
+      * **参数说明:**
+          * `config` (`Configuration`): 要校验的配置实例。
+

--- a/DrcomoCoreLib/README.md
+++ b/DrcomoCoreLib/README.md
@@ -16,8 +16,12 @@ title: DrcomoCoreLib JavaDocs
 
 
 ### 配置文件读写 (YAML)
-- **功能描述**：对 `.yml` 文件进行加载、重载、保存、读写键值、复制默认配置、获取配置节等操作。  
+- **功能描述**：对 `.yml` 文件进行加载、重载、保存、读写键值、复制默认配置、获取配置节等操作。
 - **查询文档**：[查看](./JavaDocs/config/YamlUtil-JavaDoc.md)
+
+### 配置校验
+- **功能描述**：在读取或重载配置后，验证必填项是否存在且类型正确。
+- **查询文档**：[查看](./JavaDocs/config/ConfigValidator-JavaDoc.md)
 
 
 ### 文本颜色处理

--- a/README.md
+++ b/README.md
@@ -111,13 +111,20 @@ public class MyAwesomePlugin extends JavaPlugin {
 本库提供以下核心工具类，所有类都需通过 `new` 关键字实例化使用：
 
   * `DebugUtil`: 分级日志工具。
-  * `YamlUtil`: YAML 配置文件管理器，可一次性加载目录内的多份配置。
+ * `YamlUtil`: YAML 配置文件管理器，可一次性加载目录内的多份配置。
+ * `ConfigValidator`: 配置校验器，结合 `YamlUtil` 在加载或热重载配置时验证必填项与数据类型。
   * `MessageService`: 支持多语言和 PlaceholderAPI 的消息管理器。
   * `SoundManager`: 音效管理器。
   * `NBTUtil`: 物品 NBT 数据操作工具。
   * `PlaceholderAPIUtil`: PlaceholderAPI 占位符注册与解析工具。
-  * `EconomyProvider`: 经济插件（Vault, PlayerPoints）的统一接口。
-  * ... 以及其他位于 `cn.drcomo.corelib` 包下的工具。
+* `EconomyProvider`: 经济插件（Vault, PlayerPoints）的统一接口。
+* ... 以及其他位于 `cn.drcomo.corelib` 包下的工具。
+
+### 何时使用 ConfigValidator?
+
+在读取或重新加载配置文件后，如需确保配置键存在且类型正确，可使用 `ConfigValidator`。
+先通过 `validateString`、`validateNumber` 等方法声明字段规则，再调用 `validate(cfg)`
+获得 `ValidationResult`，根据 `isSuccess()` 决定是否继续执行插件逻辑。
 
 ### **优化点分析：**
 

--- a/src/main/java/cn/drcomo/corelib/config/ConfigValidator.java
+++ b/src/main/java/cn/drcomo/corelib/config/ConfigValidator.java
@@ -1,0 +1,90 @@
+package cn.drcomo.corelib.config;
+
+import cn.drcomo.corelib.util.DebugUtil;
+import org.bukkit.configuration.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 配置校验器，结合 {@link YamlUtil} 提供的配置对象进行字段验证。
+ * <p>使用链式 API 声明各字段的类型和约束，最后调用 {@link #validate(Configuration)} 获取结果。</p>
+ */
+public class ConfigValidator {
+
+    private final YamlUtil yamlUtil;
+    private final DebugUtil logger;
+    private final List<ValidatorBuilder> builders = new ArrayList<>();
+
+    /**
+     * 构造配置校验器
+     *
+     * @param yamlUtil YamlUtil 实例
+     * @param logger   DebugUtil 实例
+     */
+    public ConfigValidator(YamlUtil yamlUtil, DebugUtil logger) {
+        this.yamlUtil = yamlUtil;
+        this.logger = logger;
+    }
+
+    /**
+     * 声明一个字符串配置项
+     *
+     * @param path 配置路径
+     * @return 构建器，可继续设置约束
+     */
+    public ValidatorBuilder validateString(String path) {
+        ValidatorBuilder b = new ValidatorBuilder(path, ValidatorBuilder.ValueType.STRING);
+        builders.add(b);
+        return b;
+    }
+
+    /**
+     * 声明一个数值配置项
+     *
+     * @param path 配置路径
+     * @return 构建器，可继续设置约束
+     */
+    public ValidatorBuilder validateNumber(String path) {
+        ValidatorBuilder b = new ValidatorBuilder(path, ValidatorBuilder.ValueType.NUMBER);
+        builders.add(b);
+        return b;
+    }
+
+    /**
+     * 声明一个枚举配置项
+     *
+     * @param path  配置路径
+     * @param clazz 枚举类型
+     * @param <E>   枚举泛型
+     * @return 构建器，可继续设置约束
+     */
+    public <E extends Enum<E>> ValidatorBuilder validateEnum(String path, Class<E> clazz) {
+        ValidatorBuilder b = new ValidatorBuilder(path, ValidatorBuilder.ValueType.ENUM, clazz);
+        builders.add(b);
+        return b;
+    }
+
+    /**
+     * 对给定配置对象执行校验
+     *
+     * @param cfg 配置对象
+     * @return 校验结果
+     */
+    public ValidationResult validate(Configuration cfg) {
+        List<String> errors = new ArrayList<>();
+        for (ValidatorBuilder b : builders) {
+            b.apply(cfg, errors);
+        }
+        boolean ok = errors.isEmpty();
+        if (ok) {
+            logger.debug("配置校验通过");
+        } else {
+            logger.warn("配置校验失败，共 " + errors.size() + " 处错误");
+            for (String msg : errors) {
+                logger.warn(msg);
+            }
+        }
+        return new ValidationResult(ok, errors);
+    }
+}

--- a/src/main/java/cn/drcomo/corelib/config/ValidationResult.java
+++ b/src/main/java/cn/drcomo/corelib/config/ValidationResult.java
@@ -1,0 +1,33 @@
+package cn.drcomo.corelib.config;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 封装配置校验结果的简单数据类。
+ */
+public class ValidationResult {
+    private final boolean success;
+    private final List<String> errors;
+
+    /**
+     * 构造校验结果
+     *
+     * @param success 是否全部通过
+     * @param errors  错误信息列表
+     */
+    public ValidationResult(boolean success, List<String> errors) {
+        this.success = success;
+        this.errors = errors == null ? List.of() : List.copyOf(errors);
+    }
+
+    /** 判断是否校验通过 */
+    public boolean isSuccess() {
+        return success;
+    }
+
+    /** 获取所有错误信息（只读） */
+    public List<String> getErrors() {
+        return Collections.unmodifiableList(errors);
+    }
+}

--- a/src/main/java/cn/drcomo/corelib/config/ValidatorBuilder.java
+++ b/src/main/java/cn/drcomo/corelib/config/ValidatorBuilder.java
@@ -1,0 +1,116 @@
+package cn.drcomo.corelib.config;
+
+import org.bukkit.configuration.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * 单个配置项的校验构建器。
+ * <p>由 {@link ConfigValidator} 创建并使用。</p>
+ */
+public class ValidatorBuilder {
+
+    /** 可验证的值类型 */
+    enum ValueType { STRING, NUMBER, ENUM }
+
+    private final String path;
+    private final ValueType type;
+    private final Class<? extends Enum<?>> enumClass;
+    private boolean required;
+    private final List<CustomRule> customs = new ArrayList<>();
+
+    ValidatorBuilder(String path, ValueType type) {
+        this(path, type, null);
+    }
+
+    ValidatorBuilder(String path, ValueType type, Class<? extends Enum<?>> enumClass) {
+        this.path = path;
+        this.type = type;
+        this.enumClass = enumClass;
+    }
+
+    /** 标记该配置项为必须存在 */
+    public ValidatorBuilder required() {
+        this.required = true;
+        return this;
+    }
+
+    /**
+     * 添加自定义校验规则。
+     *
+     * @param rule    断言函数，返回 true 表示通过
+     * @param message 失败时的提示
+     * @return 构建器本身
+     */
+    public ValidatorBuilder custom(Predicate<Object> rule, String message) {
+        customs.add(new CustomRule(rule, message));
+        return this;
+    }
+
+    /** 执行校验，将错误信息写入给定列表 */
+    void apply(Configuration cfg, List<String> errors) {
+        if (!cfg.contains(path)) {
+            if (required) {
+                errors.add("缺少配置项: " + path);
+            }
+            return;
+        }
+        Object value = cfg.get(path);
+        switch (type) {
+            case STRING:
+                if (!(value instanceof String)) {
+                    errors.add("配置 '" + path + "' 应为字符串");
+                    return;
+                }
+                break;
+            case NUMBER:
+                if (!(value instanceof Number)) {
+                    // 尝试将字符串解析为数字
+                    if (value instanceof String) {
+                        try {
+                            Double.parseDouble((String) value);
+                        } catch (NumberFormatException e) {
+                            errors.add("配置 '" + path + "' 不是有效数字");
+                            return;
+                        }
+                    } else {
+                        errors.add("配置 '" + path + "' 类型错误，期望数字");
+                        return;
+                    }
+                }
+                break;
+            case ENUM:
+                if (!(value instanceof String)) {
+                    errors.add("配置 '" + path + "' 应为字符串");
+                    return;
+                }
+                String enumVal = ((String) value).toUpperCase();
+                try {
+                    Enum.valueOf((Class) enumClass, enumVal);
+                } catch (IllegalArgumentException e) {
+                    errors.add("配置 '" + path + "' 非法枚举值: " + value);
+                    return;
+                }
+                break;
+            default:
+                break;
+        }
+        for (CustomRule cr : customs) {
+            if (!cr.rule.test(value)) {
+                errors.add(cr.message + " -> " + path);
+            }
+        }
+    }
+
+    /** 自定义校验规则 */
+    private static class CustomRule {
+        final Predicate<Object> rule;
+        final String message;
+        CustomRule(Predicate<Object> rule, String message) {
+            this.rule = rule;
+            this.message = message;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add ConfigValidator with fluent validation API
- include ValidatorBuilder and ValidationResult support classes
- document usage in ConfigValidator-JavaDoc
- explain ConfigValidator use cases in README

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ccd3dba288330953eae66715aca76