### PR TITLE
Add JsonUtil utility

### DIFF
--- a/DrcomoCoreLib/JavaDocs/json/JsonUtil-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/json/JsonUtil-JavaDoc.md
@@ -1,0 +1,60 @@
+### `JsonUtil.java`
+
+**1. 概述 (Overview)**
+
+  * **完整路径:** `cn.drcomo.corelib.json.JsonUtil`
+  * **核心职责:** 一个封装了 Gson 的通用 JSON 工具类，提供对象与 JSON 字符串的相互转换，以及文件读写、校验与格式化等功能。
+
+**2. 如何实例化 (Initialization)**
+
+  * **核心思想:** 每个插件应创建自己的 `JsonUtil` 实例，通过构造函数注入 `DebugUtil`，可选地传入自定义 `Gson`。
+  * **构造函数:** `public JsonUtil(DebugUtil logger)`  
+    `public JsonUtil(DebugUtil logger, Gson gson)`
+  * **代码示例:**
+    ```java
+    DebugUtil logger = new DebugUtil(this, DebugUtil.LogLevel.DEBUG);
+    JsonUtil jsonUtil = new JsonUtil(logger);
+
+    Map<String, Object> data = Map.of("name", "DrComo", "level", 99);
+    Path file = Paths.get(getDataFolder().toString(), "data.json");
+    jsonUtil.writeJsonFile(file, data);
+    ```
+
+**3. 公共API方法 (Public API Methods)**
+
+  * #### `toJson(Object obj)`
+      * **返回类型:** `String`
+      * **功能描述:** 将对象序列化为 JSON 字符串。
+
+  * #### `fromJson(String json, Class<T> clazz)`
+      * **返回类型:** `<T> T`
+      * **功能描述:** 按给定类解析 JSON 字符串。
+
+  * #### `fromJson(String json, TypeToken<T> type)`
+      * **返回类型:** `<T> T`
+      * **功能描述:** 使用 `TypeToken` 解析带泛型的复杂对象。
+
+  * #### `readJsonFile(Path path, Class<T> clazz)`
+      * **返回类型:** `<T> T`
+      * **功能描述:** 从文件读取 JSON 并解析成指定类型。
+
+  * #### `readJsonFile(Path path, TypeToken<T> type)`
+      * **返回类型:** `<T> T`
+      * **功能描述:** 读取文件并按 `TypeToken` 解析。
+
+  * #### `writeJsonFile(Path path, Object obj)`
+      * **返回类型:** `void`
+      * **功能描述:** 将对象以 JSON 形式写入文件，自动创建缺失的目录。
+
+  * #### `isValidJson(String json)`
+      * **返回类型:** `boolean`
+      * **功能描述:** 判断字符串是否是合法 JSON。
+
+  * #### `prettyPrint(String json)`
+      * **返回类型:** `String`
+      * **功能描述:** 以缩进格式返回更易阅读的 JSON 字符串。
+
+**4. 典型用法 (Typical Usage)**
+
+  * 在插件加载时创建 `JsonUtil` 实例，配合其他工具持久化数据；
+  * 当解析或写入失败时，通过 `DebugUtil` 输出详细日志，方便排查问题。

--- a/README.md
+++ b/README.md
@@ -115,9 +115,17 @@ public class MyAwesomePlugin extends JavaPlugin {
   * `MessageService`: 支持多语言和 PlaceholderAPI 的消息管理器。
   * `SoundManager`: 音效管理器。
   * `NBTUtil`: 物品 NBT 数据操作工具。
+  * `JsonUtil`: 适用于保存或读取 JSON 文件、验证与美化 JSON 字符串。
   * `PlaceholderAPIUtil`: PlaceholderAPI 占位符注册与解析工具。
   * `EconomyProvider`: 经济插件（Vault, PlayerPoints）的统一接口。
   * ... 以及其他位于 `cn.drcomo.corelib` 包下的工具。
+
+### **何时使用 JsonUtil？**
+
+当你需要将数据对象转为 JSON 保存到磁盘，或从 JSON 文件恢复为 Java 对象时，可调用
+`writeJsonFile` 与 `readJsonFile`。若只是临时序列化或反序列化字符串，可使用 `toJson`
+和 `fromJson`。`isValidJson` 适合在处理外部输入前做格式校验，`prettyPrint` 则常用于
+调试时输出更可读的 JSON 内容。
 
 ### **优化点分析：**
 

--- a/pom.xml
+++ b/pom.xml
@@ -124,5 +124,11 @@
             <version>6.2.1</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/cn/drcomo/corelib/json/JsonUtil.java
+++ b/src/main/java/cn/drcomo/corelib/json/JsonUtil.java
@@ -1,0 +1,179 @@
+package cn.drcomo.corelib.json;
+
+import cn.drcomo.corelib.util.DebugUtil;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
+import com.google.gson.reflect.TypeToken;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * JSON 工具类，封装了常用的序列化与文件读写操作。
+ * <p>通过注入 {@link DebugUtil} 输出调试信息，并持有一个 {@link Gson} 实例。</p>
+ */
+public class JsonUtil {
+
+    private final DebugUtil logger;
+    private final Gson gson;
+
+    /**
+     * 构造函数，使用默认的 {@link Gson} 配置。
+     *
+     * @param logger DebugUtil 实例
+     */
+    public JsonUtil(DebugUtil logger) {
+        this(logger, new GsonBuilder().create());
+    }
+
+    /**
+     * 构造函数，允许自定义 {@link Gson} 实例。
+     *
+     * @param logger DebugUtil 实例
+     * @param gson   自定义的 Gson 实例
+     */
+    public JsonUtil(DebugUtil logger, Gson gson) {
+        this.logger = logger;
+        this.gson = gson == null ? new GsonBuilder().create() : gson;
+    }
+
+    /**
+     * 将对象序列化为 JSON 字符串。
+     *
+     * @param obj 需要序列化的对象
+     * @return JSON 字符串
+     */
+    public String toJson(Object obj) {
+        try {
+            return gson.toJson(obj);
+        } catch (Exception e) {
+            logger.error("序列化对象失败", e);
+            return "";
+        }
+    }
+
+    /**
+     * 从 JSON 字符串反序列化对象。
+     *
+     * @param json  JSON 字符串
+     * @param clazz 目标类型
+     * @param <T>   泛型类型
+     * @return 解析后的对象
+     * @throws IllegalArgumentException JSON 解析失败
+     */
+    public <T> T fromJson(String json, Class<T> clazz) throws IllegalArgumentException {
+        try {
+            return gson.fromJson(json, clazz);
+        } catch (JsonParseException e) {
+            logger.error("解析 JSON 失败", e);
+            throw new IllegalArgumentException("Invalid JSON", e);
+        }
+    }
+
+    /**
+     * 使用 {@link TypeToken} 解析复杂泛型类型。
+     *
+     * @param json      JSON 字符串
+     * @param typeToken Gson TypeToken
+     * @param <T>       泛型类型
+     * @return 解析后的对象
+     * @throws IllegalArgumentException JSON 解析失败
+     */
+    public <T> T fromJson(String json, TypeToken<T> typeToken) throws IllegalArgumentException {
+        try {
+            return gson.fromJson(json, typeToken.getType());
+        } catch (JsonParseException e) {
+            logger.error("解析 JSON 失败", e);
+            throw new IllegalArgumentException("Invalid JSON", e);
+        }
+    }
+
+    /**
+     * 从文件读取并解析 JSON。
+     *
+     * @param path  文件路径
+     * @param clazz 目标类型
+     * @param <T>   泛型类型
+     * @return 解析后的对象
+     * @throws IllegalStateException 读取或解析失败
+     */
+    public <T> T readJsonFile(Path path, Class<T> clazz) throws IllegalStateException {
+        try {
+            String json = Files.readString(path, StandardCharsets.UTF_8);
+            return fromJson(json, clazz);
+        } catch (IOException e) {
+            logger.error("读取 JSON 文件失败: " + path, e);
+            throw new IllegalStateException("无法读取文件", e);
+        }
+    }
+
+    /**
+     * 从文件读取并解析复杂泛型类型。
+     *
+     * @param path      文件路径
+     * @param typeToken Gson TypeToken
+     * @param <T>       泛型类型
+     * @return 解析后的对象
+     * @throws IllegalStateException 读取或解析失败
+     */
+    public <T> T readJsonFile(Path path, TypeToken<T> typeToken) throws IllegalStateException {
+        try {
+            String json = Files.readString(path, StandardCharsets.UTF_8);
+            return fromJson(json, typeToken);
+        } catch (IOException e) {
+            logger.error("读取 JSON 文件失败: " + path, e);
+            throw new IllegalStateException("无法读取文件", e);
+        }
+    }
+
+    /**
+     * 将对象写入 JSON 文件，自动创建缺失的父目录。
+     *
+     * @param path 文件路径
+     * @param obj  待写入对象
+     */
+    public void writeJsonFile(Path path, Object obj) {
+        try {
+            if (path.getParent() != null) {
+                Files.createDirectories(path.getParent());
+            }
+            Files.writeString(path, gson.toJson(obj), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            logger.error("写入 JSON 文件失败: " + path, e);
+        }
+    }
+
+    /**
+     * 检查字符串是否为合法 JSON。
+     *
+     * @param json JSON 字符串
+     * @return 如果合法返回 true
+     */
+    public boolean isValidJson(String json) {
+        try {
+            gson.fromJson(json, Object.class);
+            return true;
+        } catch (JsonParseException e) {
+            return false;
+        }
+    }
+
+    /**
+     * 美化输出 JSON 字符串。
+     *
+     * @param json 原始 JSON
+     * @return 格式化后的 JSON
+     */
+    public String prettyPrint(String json) {
+        try {
+            Object obj = gson.fromJson(json, Object.class);
+            return new GsonBuilder().setPrettyPrinting().create().toJson(obj);
+        } catch (JsonParseException e) {
+            logger.error("美化 JSON 失败", e);
+            return json;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `JsonUtil` for serializing, deserializing and working with JSON files
- add Gson dependency
- document `JsonUtil`
- document when to use `JsonUtil` in README

## Testing
- `mvn -q -DskipTests package` *(failed: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ccd25a160833081f9e55427b47175