### PR TITLE
Add AsyncTaskManager util

### DIFF
--- a/DrcomoCoreLib/JavaDocs/async/AsyncTaskManager-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/async/AsyncTaskManager-JavaDoc.md
@@ -1,0 +1,40 @@
+### `AsyncTaskManager.java`
+
+**1. 概述 (Overview)**
+
+  * **完整路径:** `cn.drcomo.corelib.async.AsyncTaskManager`
+  * **核心职责:** 提供基于线程池的异步任务提交與調度能力，並在執行過程中自動捕獲並記錄例外。
+
+**2. 如何实例化 (Initialization)**
+
+  * **核心思想:** 每个子插件根据自身需求创建独立实例，并在插件关闭时调用 `shutdown()` 释放线程资源。
+  * **构造函数:** `public AsyncTaskManager(Plugin plugin, DebugUtil logger)`
+  * **代码示例:**
+    ```java
+    Plugin plugin = this;
+    DebugUtil logger = new DebugUtil(plugin, DebugUtil.LogLevel.INFO);
+    AsyncTaskManager manager = new AsyncTaskManager(plugin, logger);
+
+    manager.submitAsync(() -> logger.info("run"));
+    ```
+
+**3. 公共API方法 (Public API Methods)**
+
+  * #### `Future<?> submitAsync(Runnable task)`
+      * **返回类型:** `Future<?>`
+      * **功能描述:** 在内部线程池中异步执行一个 `Runnable`。
+  * #### `<T> Future<T> submitAsync(Callable<T> task)`
+      * **返回类型:** `Future<T>`
+      * **功能描述:** 在内部线程池中执行可返回结果的任务。
+  * #### `ScheduledFuture<?> scheduleAsync(Runnable task, long delay, TimeUnit unit)`
+      * **返回类型:** `ScheduledFuture<?>`
+      * **功能描述:** 延迟指定时间后执行任务。
+  * #### `ScheduledFuture<?> scheduleAtFixedRate(Runnable task, long initialDelay, long period, TimeUnit unit)`
+      * **返回类型:** `ScheduledFuture<?>`
+      * **功能描述:** 以固定间隔重复执行任务。
+  * #### `List<Future<?>> submitBatch(Collection<? extends Runnable> tasks)`
+      * **返回类型:** `List<Future<?>>`
+      * **功能描述:** 批量提交多个 `Runnable` 任务。
+  * #### `void shutdown()`
+      * **返回类型:** `void`
+      * **功能描述:** 关闭内部线程池，停止接受新任务。

--- a/README.md
+++ b/README.md
@@ -117,7 +117,17 @@ public class MyAwesomePlugin extends JavaPlugin {
   * `NBTUtil`: 物品 NBT 数据操作工具。
   * `PlaceholderAPIUtil`: PlaceholderAPI 占位符注册与解析工具。
   * `EconomyProvider`: 经济插件（Vault, PlayerPoints）的统一接口。
+  * `AsyncTaskManager`: 统一管理异步任务与定时调度的工具。
   * ... 以及其他位于 `cn.drcomo.corelib` 包下的工具。
+
+### AsyncTaskManager 使用指引
+
+* `submitAsync(Runnable)`: 当你只需在后台执行任务而不关心返回值时使用。
+* `submitAsync(Callable<T>)`: 当任务需要产出结果并通过 `Future` 获取时使用。
+* `scheduleAsync(Runnable, long, TimeUnit)`: 需要延迟执行一次任务时使用。
+* `scheduleAtFixedRate(Runnable, long, long, TimeUnit)`: 需要固定间隔循环执行任务时使用。
+* `submitBatch(Collection<? extends Runnable>)`: 一次性提交多个独立任务时使用。
+* `shutdown()`: 在插件关闭或不再需要异步能力时调用以回收线程。
 
 ### **优化点分析：**
 

--- a/src/main/java/cn/drcomo/corelib/async/AsyncTaskManager.java
+++ b/src/main/java/cn/drcomo/corelib/async/AsyncTaskManager.java
@@ -1,0 +1,139 @@
+package cn.drcomo.corelib.async;
+
+import cn.drcomo.corelib.util.DebugUtil;
+import org.bukkit.plugin.Plugin;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * 异步任务管理器。
+ * <p>
+ * 内部维护普通和定时两种线程池，用于执行和调度异步任务。
+ * 所有回调中的异常都会被捕获并记录到提供的 {@link DebugUtil} 实例。
+ * </p>
+ */
+public class AsyncTaskManager {
+
+    private static final AtomicInteger THREAD_COUNTER = new AtomicInteger(1);
+
+    private final Plugin plugin;
+    private final DebugUtil logger;
+    private final ExecutorService executor;
+    private final ScheduledExecutorService scheduler;
+
+    /**
+     * 构造异步任务管理器。
+     *
+     * @param plugin 插件实例
+     * @param logger DebugUtil 日志工具
+     */
+    public AsyncTaskManager(Plugin plugin, DebugUtil logger) {
+        this.plugin = plugin;
+        this.logger = logger;
+        this.executor = Executors.newCachedThreadPool(r -> {
+            Thread t = new Thread(r, plugin.getName() + "-Async-" + THREAD_COUNTER.getAndIncrement());
+            t.setDaemon(true);
+            return t;
+        });
+        this.scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, plugin.getName() + "-Scheduler-" + THREAD_COUNTER.getAndIncrement());
+            t.setDaemon(true);
+            return t;
+        });
+    }
+
+    /**
+     * 提交一个异步任务。
+     *
+     * @param task 需要执行的任务
+     * @return 代表任务的 Future
+     */
+    public Future<?> submitAsync(Runnable task) {
+        return executor.submit(wrap(task));
+    }
+
+    /**
+     * 提交一个异步任务并返回结果。
+     *
+     * @param task 可返回结果的任务
+     * @param <T>  返回值类型
+     * @return 代表任务的 Future
+     */
+    public <T> Future<T> submitAsync(Callable<T> task) {
+        return executor.submit(wrap(task));
+    }
+
+    /**
+     * 延迟执行异步任务。
+     *
+     * @param task  任务
+     * @param delay 延迟时间
+     * @param unit  时间单位
+     * @return 调度结果句柄
+     */
+    public ScheduledFuture<?> scheduleAsync(Runnable task, long delay, TimeUnit unit) {
+        return scheduler.schedule(wrap(task), delay, unit);
+    }
+
+    /**
+     * 以固定频率执行任务。
+     *
+     * @param task         任务
+     * @param initialDelay 首次执行前的延迟
+     * @param period       间隔时间
+     * @param unit         时间单位
+     * @return 调度结果句柄
+     */
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable task, long initialDelay, long period, TimeUnit unit) {
+        return scheduler.scheduleAtFixedRate(wrap(task), initialDelay, period, unit);
+    }
+
+    /**
+     * 批量提交多个任务。
+     *
+     * @param tasks 任务集合
+     * @return 每个任务对应的 Future 列表
+     */
+    public List<Future<?>> submitBatch(Collection<? extends Runnable> tasks) {
+        List<Future<?>> futures = new ArrayList<>();
+        if (tasks != null) {
+            for (Runnable r : tasks) {
+                futures.add(submitAsync(r));
+            }
+        }
+        return futures;
+    }
+
+    /**
+     * 关闭内部线程池，停止接受新任务。
+     */
+    public void shutdown() {
+        executor.shutdown();
+        scheduler.shutdown();
+    }
+
+    private Runnable wrap(Runnable task) {
+        return () -> {
+            try {
+                task.run();
+            } catch (Exception e) {
+                logger.error("异步任务执行异常", e);
+            }
+        };
+    }
+
+    private <T> Callable<T> wrap(Callable<T> task) {
+        return () -> {
+            try {
+                return task.call();
+            } catch (Exception e) {
+                logger.error("异步任务执行异常", e);
+                throw e;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add `AsyncTaskManager` to manage async execution and scheduling
- document `AsyncTaskManager` usage
- update README with usage of `AsyncTaskManager`

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ccd1e5bc88330b30fd849a21044fa