### PR TITLE
Add executor customization for AsyncTaskManager

### DIFF
--- a/DrcomoCoreLib/JavaDocs/async/AsyncTaskManager-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/async/AsyncTaskManager-JavaDoc.md
@@ -9,14 +9,29 @@
 
   * **核心思想:** 每个子插件根据自身需求创建独立实例，并在插件关闭时调用 `shutdown()` 释放线程资源。
   * **构造函数:** `public AsyncTaskManager(Plugin plugin, DebugUtil logger)`
+  * **Builder:** `AsyncTaskManager.newBuilder(plugin, logger)` 可自定义线程池。
   * **代码示例:**
     ```java
     Plugin plugin = this;
     DebugUtil logger = new DebugUtil(plugin, DebugUtil.LogLevel.INFO);
+
+    // 默认线程池
     AsyncTaskManager manager = new AsyncTaskManager(plugin, logger);
+
+    // 自定义线程池与调度器
+    ExecutorService exec = Executors.newFixedThreadPool(4);
+    ScheduledExecutorService sched = Executors.newSingleThreadScheduledExecutor();
+    AsyncTaskManager custom = AsyncTaskManager
+            .newBuilder(plugin, logger)
+            .executor(exec)
+            .scheduler(sched)
+            .build();
 
     manager.submitAsync(() -> logger.info("run"));
     ```
+
+  * **Bukkit 调度器示例:** 可以封装 `BukkitScheduler` 实现 `ScheduledExecutorService`，
+    然后通过 `builder.scheduler()` 传入，实现与服务器主调度器的统一管理。
 
 **3. 公共API方法 (Public API Methods)**
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,22 @@ public class MyAwesomePlugin extends JavaPlugin {
   * `PerformanceUtil`: 获取 TPS、CPU、内存与 GC 数据的性能监控工具。
   * ... 以及其他位于 `cn.drcomo.corelib` 包下的工具。
 
+### **更换线程池示例**
+
+通过 `AsyncTaskManager.newBuilder()` 可接入自定义线程池或调度器。
+
+```java
+ExecutorService exec = Executors.newFixedThreadPool(4);
+ScheduledExecutorService sched = Executors.newSingleThreadScheduledExecutor();
+AsyncTaskManager manager = AsyncTaskManager
+        .newBuilder(this, myLogger)
+        .executor(exec)
+        .scheduler(sched) // 可替换为封装 BukkitScheduler 的实现
+        .build();
+```
+
+若需使用 Bukkit 原生调度器，可将 `BukkitScheduler` 封装为 `ScheduledExecutorService` 后传入 `scheduler()`。
+
 ### **优化点分析：**
 
 1.  **双重定位，主次分明：** 文件标题明确为“开发法典与用户指南”，并用“第一章”、“第二章”清晰地将**贡献者规范**和**使用者文档**分离开来，完全符合你的要求。


### PR DESCRIPTION
## Summary
- allow building `AsyncTaskManager` with custom ExecutorService and ScheduledExecutorService
- document builder usage and Bukkit scheduler example

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e59485c98833088bfce5abdaa6a15