### PR TITLE
Add runtime message service config options

### DIFF
--- a/DrcomoCoreLib/JavaDocs/message/MessageService-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/message/MessageService-JavaDoc.md
@@ -65,6 +65,24 @@
             return false;
         }
         ```
+        
+  * #### `switchLanguage(String newPath)`
+
+      * **返回类型:** `void`
+      * **功能描述:** 切换语言文件路径并立即重新加载消息。
+      * **参数说明:**
+          * `newPath` (`String`): 新的语言文件路径（不含 `.yml`）。
+      * **使用示例:**
+        ```java
+        messageService.switchLanguage("languages/en_US");
+        ```
+
+  * #### `setKeyPrefix(String newPrefix)`
+
+      * **返回类型:** `void`
+      * **功能描述:** 动态修改所有消息键的统一前缀。
+      * **参数说明:**
+          * `newPrefix` (`String`): 新前缀，可为 `null`。
 
   * #### `getRaw(String key)`
 
@@ -163,6 +181,21 @@
             return "无效参数";
         });
         ```
+
+  * #### `setInternalPlaceholderPattern(Pattern pattern)`
+
+      * **返回类型:** `void`
+      * **功能描述:** 自定义内部占位符的匹配正则。
+      * **参数说明:**
+          * `pattern` (`Pattern`): 新的匹配模式。
+
+  * #### `addPlaceholderRule(Pattern pattern, BiFunction<Player, Matcher, String> resolver)`
+
+      * **返回类型:** `void`
+      * **功能描述:** 新增一条基于正则的自定义占位符解析规则。
+      * **参数说明:**
+          * `pattern` (`Pattern`): 用于匹配占位符的正则。
+          * `resolver` (`BiFunction<Player, Matcher, String>`): 当匹配到占位符时调用的解析函数。
 
   * #### `send(Player player, String key)`
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ public class MyAwesomePlugin extends JavaPlugin {
   * `DebugUtil`: 分级日志工具。
  * `YamlUtil`: YAML 配置文件管理器，可一次性加载目录内的多份配置。
  * `ConfigValidator`: 配置校验器，结合 `YamlUtil` 在加载或热重载配置时验证必填项与数据类型。
-  * `MessageService`: 支持多语言和 PlaceholderAPI 的消息管理器。
+  * `MessageService`: 支持多语言和 PlaceholderAPI 的消息管理器，可在运行时切换语言文件或调整键前缀，并允许自定义占位符解析规则。
   * `SoundManager`: 音效管理器。
   * `NBTUtil`: 物品 NBT 数据操作工具。
   * `JsonUtil`: 适用于保存或读取 JSON 文件、验证与美化 JSON 字符串。


### PR DESCRIPTION
## Summary
- allow modifying language path and key prefix while running
- expose APIs for custom placeholder patterns
- document new methods in MessageService docs
- mention runtime features in README

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e596393348330afb8f9c4880673bd