### PR TITLE
Add SQLite connection pool with async support

### DIFF
--- a/DrcomoCoreLib/JavaDocs/database/SQLiteDB-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/database/SQLiteDB-JavaDoc.md
@@ -3,7 +3,7 @@
 **1. 概述 (Overview)**
 
   * **完整路径:** `cn.drcomo.corelib.database.SQLiteDB`
-  * **核心职责:** 管理 SQLite 连接、初始化表结构，并提供最基础的增删改查以及事务执行能力。它遵循零硬编码和控制反转原则，由调用方传入数据库路径和初始化脚本。
+  * **核心职责:** 管理 SQLite 连接、初始化表结构，并提供最基础的增删改查以及事务执行能力。自 1.1 起内部集成 HikariCP 连接池，保证多线程环境下安全获取连接。它遵循零硬编码和控制反转原则，由调用方传入数据库路径和初始化脚本。
 
 **2. 如何实例化 (Initialization)**
 
@@ -67,6 +67,36 @@
       * **功能描述:** 关闭自动提交后执行回调内的多次数据库更新，若发生异常则回滚，否则提交。
       * **参数说明:**
           * `callback` (`SQLRunnable`): 在事务中执行的逻辑。
+
+  * #### `connectAsync()`
+
+      * **返回类型:** `CompletableFuture<Void>`
+      * **功能描述:** 异步打开连接，底层仍使用连接池。
+
+  * #### `initializeSchemaAsync()`
+
+      * **返回类型:** `CompletableFuture<Void>`
+      * **功能描述:** 在后台线程执行初始化脚本。
+
+  * #### `executeUpdateAsync(String sql, Object... params)`
+
+      * **返回类型:** `CompletableFuture<Integer>`
+      * **功能描述:** 异步执行更新语句，返回影响行数。
+
+  * #### `queryOneAsync(String sql, ResultSetHandler<T> handler, Object... params)`
+
+      * **返回类型:** `CompletableFuture<T>`
+      * **功能描述:** 异步查询单行数据。
+
+  * #### `queryListAsync(String sql, ResultSetHandler<T> handler, Object... params)`
+
+      * **返回类型:** `CompletableFuture<List<T>>`
+      * **功能描述:** 异步查询多行数据。
+
+  * #### `transactionAsync(SQLRunnable callback)`
+
+      * **返回类型:** `CompletableFuture<Void>`
+      * **功能描述:** 异步执行事务逻辑。
 
 **4. 内部接口 (Inner Interfaces)**
 

--- a/DrcomoCoreLib/README.md
+++ b/DrcomoCoreLib/README.md
@@ -109,5 +109,5 @@ title: DrcomoCoreLib JavaDocs
 - **关联查询 (辅助工具)**：[查看](./JavaDocs/gui/GuiManager-JavaDoc.md) (用于安全播放音效、清理光标、检查危险点击等)
 
 ### 数据库操作 (SQLite)
-- **功能描述**：连接管理 SQLite 数据库，初始化表结构，执行增删改查（CRUD）、事务处理。  
+- **功能描述**：连接管理 SQLite 数据库，初始化表结构，执行增删改查（CRUD）、事务处理。内置 HikariCP 连接池并提供异步接口，适合并发环境。
 - **查询文档**：[查看](./JavaDocs/database)

--- a/src/main/java/cn/drcomo/corelib/database/SQLiteDB.java
+++ b/src/main/java/cn/drcomo/corelib/database/SQLiteDB.java
@@ -1,20 +1,27 @@
 package cn.drcomo.corelib.database;
 
 import org.bukkit.plugin.Plugin;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 import java.sql.*;
 import java.util.List;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.IOException;
 import java.io.File;
 import java.io.InputStream;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 /**
  * SQLite 数据库工具，管理连接、初始化表结构以及
  * 基础 CRUD 操作。
+ * <p>
+ * 自 1.1 起内部使用 HikariCP 维护连接池，确保在多线程环境下安全获取连接。
+ * 同时提供一系列异步方法，便于在后台执行数据库操作。
+ * </p>
  * <p>
  * 请在构造时传入所需的插件实例、相对路径
  * 和初始化脚本列表。
@@ -25,7 +32,8 @@ public class SQLiteDB {
     private final Plugin plugin;
     private final String dbFilePath;
     private final List<String> initScripts;
-    private Connection connection;
+    private HikariDataSource dataSource;
+    private final ThreadLocal<Connection> txConnection = new ThreadLocal<>();
 
     /**
      * 构造方法。
@@ -53,8 +61,12 @@ public class SQLiteDB {
         if (parent != null && !parent.exists()) {
             parent.mkdirs();
         }
-        this.connection = DriverManager.getConnection("jdbc:sqlite:" + dbFilePath);
-        this.connection.setAutoCommit(false);
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl("jdbc:sqlite:" + dbFilePath);
+        config.setPoolName(plugin.getName() + "-SQLitePool");
+        config.setMaximumPoolSize(10);
+        config.setConnectionTestQuery("SELECT 1");
+        this.dataSource = new HikariDataSource(config);
     }
 
     /**
@@ -62,18 +74,9 @@ public class SQLiteDB {
      * 如果连接已被关闭将会被忽略。
      */
     public void disconnect() {
-        if (connection != null) {
-            try {
-                if (!connection.getAutoCommit()) {
-                    connection.rollback();
-                }
-            } catch (SQLException ignored) {
-            }
-            try {
-                connection.close();
-            } catch (SQLException ignored) {
-            }
-            connection = null;
+        if (dataSource != null) {
+            dataSource.close();
+            dataSource = null;
         }
     }
 
@@ -85,27 +88,33 @@ public class SQLiteDB {
      * @throws IOException  脚本读取失败时抛出
      */
     public void initializeSchema() throws SQLException, IOException {
-        for (String path : initScripts) {
-            try (InputStream in = plugin.getResource(path)) {
-                if (in == null) {
-                    continue;
-                }
-                try (BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
-                    String sql = reader.lines().collect(Collectors.joining("\n"));
-                    for (String statement : sql.split(";")) {
-                        String trimmed = statement.trim();
-                        if (!trimmed.isEmpty()) {
-                            try (PreparedStatement ps = connection.prepareStatement(trimmed)) {
-                                ps.executeUpdate();
+        Connection conn = borrowConnection();
+        try {
+            for (String path : initScripts) {
+                try (InputStream in = plugin.getResource(path)) {
+                    if (in == null) {
+                        continue;
+                    }
+                    try (BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
+                        String sql = reader.lines().collect(Collectors.joining("\n"));
+                        for (String statement : sql.split(";")) {
+                            String trimmed = statement.trim();
+                            if (!trimmed.isEmpty()) {
+                                try (PreparedStatement ps = conn.prepareStatement(trimmed)) {
+                                    ps.executeUpdate();
+                                }
                             }
                         }
                     }
                 }
             }
+            if (!conn.getAutoCommit()) {
+                conn.commit();
+            }
+        } finally {
+            returnConnection(conn);
         }
-        if (!connection.getAutoCommit()) {
-            connection.commit();
-        }
+    }
     }
 
     /**
@@ -117,13 +126,16 @@ public class SQLiteDB {
      * @throws SQLException 执行失败时抛出
      */
     public int executeUpdate(String sql, Object... params) throws SQLException {
-        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+        Connection conn = borrowConnection();
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
             setParams(ps, params);
             int rows = ps.executeUpdate();
-            if (!connection.getAutoCommit()) {
-                connection.commit();
+            if (!conn.getAutoCommit()) {
+                conn.commit();
             }
             return rows;
+        } finally {
+            returnConnection(conn);
         }
     }
 
@@ -138,11 +150,14 @@ public class SQLiteDB {
      * @throws SQLException 执行期间失败时抛出
      */
     public <T> T queryOne(String sql, ResultSetHandler<T> handler, Object... params) throws SQLException {
-        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+        Connection conn = borrowConnection();
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
             setParams(ps, params);
             try (ResultSet rs = ps.executeQuery()) {
                 return rs.next() ? handler.handle(rs) : null;
             }
+        } finally {
+            returnConnection(conn);
         }
     }
 
@@ -158,13 +173,16 @@ public class SQLiteDB {
      */
     public <T> List<T> queryList(String sql, ResultSetHandler<T> handler, Object... params) throws SQLException {
         List<T> list = new ArrayList<>();
-        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+        Connection conn = borrowConnection();
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
             setParams(ps, params);
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
                     list.add(handler.handle(rs));
                 }
             }
+        } finally {
+            returnConnection(conn);
         }
         return list;
     }
@@ -177,17 +195,81 @@ public class SQLiteDB {
      * @throws SQLException 事务中的数据操作失败时抛出
      */
     public void transaction(SQLRunnable callback) throws SQLException {
-        boolean old = connection.getAutoCommit();
-        connection.setAutoCommit(false);
-        try {
-            callback.run(this);
-            connection.commit();
-        } catch (SQLException e) {
-            connection.rollback();
-            throw e;
-        } finally {
-            connection.setAutoCommit(old);
+        try (Connection conn = dataSource.getConnection()) {
+            txConnection.set(conn);
+            boolean old = conn.getAutoCommit();
+            conn.setAutoCommit(false);
+            try {
+                callback.run(this);
+                conn.commit();
+            } catch (SQLException e) {
+                conn.rollback();
+                throw e;
+            } finally {
+                conn.setAutoCommit(old);
+                txConnection.remove();
+            }
         }
+    }
+
+    public CompletableFuture<Void> connectAsync() {
+        return CompletableFuture.runAsync(() -> {
+            try {
+                connect();
+            } catch (SQLException e) {
+                throw new CompletionException(e);
+            }
+        });
+    }
+
+    public CompletableFuture<Void> initializeSchemaAsync() {
+        return CompletableFuture.runAsync(() -> {
+            try {
+                initializeSchema();
+            } catch (SQLException | IOException e) {
+                throw new CompletionException(e);
+            }
+        });
+    }
+
+    public CompletableFuture<Integer> executeUpdateAsync(String sql, Object... params) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                return executeUpdate(sql, params);
+            } catch (SQLException e) {
+                throw new CompletionException(e);
+            }
+        });
+    }
+
+    public <T> CompletableFuture<T> queryOneAsync(String sql, ResultSetHandler<T> handler, Object... params) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                return queryOne(sql, handler, params);
+            } catch (SQLException e) {
+                throw new CompletionException(e);
+            }
+        });
+    }
+
+    public <T> CompletableFuture<List<T>> queryListAsync(String sql, ResultSetHandler<T> handler, Object... params) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                return queryList(sql, handler, params);
+            } catch (SQLException e) {
+                throw new CompletionException(e);
+            }
+        });
+    }
+
+    public CompletableFuture<Void> transactionAsync(SQLRunnable callback) {
+        return CompletableFuture.runAsync(() -> {
+            try {
+                transaction(callback);
+            } catch (SQLException e) {
+                throw new CompletionException(e);
+            }
+        });
     }
 
     private void setParams(PreparedStatement ps, Object... params) throws SQLException {
@@ -195,6 +277,17 @@ public class SQLiteDB {
             for (int i = 0; i < params.length; i++) {
                 ps.setObject(i + 1, params[i]);
             }
+        }
+    }
+
+    private Connection borrowConnection() throws SQLException {
+        Connection conn = txConnection.get();
+        return conn != null ? conn : dataSource.getConnection();
+    }
+
+    private void returnConnection(Connection conn) throws SQLException {
+        if (txConnection.get() == null && conn != null) {
+            conn.close();
         }
     }
 


### PR DESCRIPTION
## Summary
- add HikariCP pool and thread-safe connection handling in `SQLiteDB`
- expose async database operations
- update database JavaDoc for pooling and async API
- update README to mention new concurrent features

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e59555d30833091b63b2f7a945efe