### PR TITLE
Add handle for YAML config watching

### DIFF
--- a/DrcomoCoreLib/JavaDocs/config/YamlUtil-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/config/YamlUtil-JavaDoc.md
@@ -155,12 +155,24 @@
 
   * #### `watchConfig(String configName, Consumer<YamlConfiguration> onChange)`
 
-      * **返回类型:** `void`
-      * **功能描述:** 使用 `WatchService` 监听配置文件变更。当文件内容被修改时，自
-      动重载该文件并执行回调函数。
+      * **返回类型:** `YamlUtil.ConfigWatchHandle`
+      * **功能描述:** 使用 `WatchService` 监听配置文件变更。当文件内容被修改时自动
+      重载该文件并执行回调函数。返回的 `ConfigWatchHandle` 可以在不再需要监听时调
+      用 `close()` 来安全地终止线程并关闭 `WatchService`。
       * **参数说明:**
           * `configName` (`String`): 文件名（不含 `.yml`）。
           * `onChange` (`Consumer<YamlConfiguration>`): 变更后的回调，参数为最新配置。
+
+  * **代码示例：**
+
+    ```java
+    // 开始监听配置文件
+    YamlUtil.ConfigWatchHandle handle =
+        yamlUtil.watchConfig("config", cfg -> logger.info("配置已更新"));
+
+    // 在插件关闭或不再需要时停止监听
+    handle.close();
+    ```
 
   * #### `getValue(String path, Class<T> type, T defaultValue)`
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ public class MyAwesomePlugin extends JavaPlugin {
 
     private DebugUtil myLogger;
     private YamlUtil myYamlUtil;
+    private YamlUtil.ConfigWatchHandle configHandle;
     private SoundManager mySoundManager;
 
     @Override
@@ -81,7 +82,7 @@ public class MyAwesomePlugin extends JavaPlugin {
         // 2. 为你的插件创建独立的 Yaml 配置工具，并注入日志实例
         myYamlUtil = new YamlUtil(this, myLogger);
         myYamlUtil.loadConfig("config");
-        myYamlUtil.watchConfig("config", updated ->
+        configHandle = myYamlUtil.watchConfig("config", updated ->
                 myLogger.info("配置文件已重新加载！"));
 
         // 3. 实例化 SoundManager，注入所有需要的依赖
@@ -107,6 +108,13 @@ public class MyAwesomePlugin extends JavaPlugin {
         archiveUtil.cleanupOldArchives("backups", 30);
 
         myLogger.info("我的插件已成功加载，并配置好了核心库工具！");
+    }
+
+    @Override
+    public void onDisable() {
+        if (configHandle != null) {
+            configHandle.close();
+        }
     }
 }
 ```


### PR DESCRIPTION
## Summary
- expose a `ConfigWatchHandle` from `watchConfig` for stopping file watchers
- document how to start and stop the watcher in README and JavaDocs

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e5951a84c8330a62b89e3c55e4efa