### PR TITLE
Add temporary volume/pitch playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ public class MyAwesomePlugin extends JavaPlugin {
             true            // 找不到音效时警告
         );
         mySoundManager.loadSounds(); // 手动加载音效
+        // 可在需要时自定义音量与音调
+        // mySoundManager.play("level_up", player.getLocation(), 0.8f, 1.2f);
 
         // 4. 使用类型安全的方式读取配置
         boolean autoSave = myYamlUtil.getValue("settings.auto-save", Boolean.class, true);

--- a/src/main/java/cn/drcomo/corelib/sound/SoundManager.java
+++ b/src/main/java/cn/drcomo/corelib/sound/SoundManager.java
@@ -164,6 +164,29 @@ public class SoundManager {
     }
 
     /**
+     * 在指定位置播放音效，并临时指定音量与音调。
+     * <p>
+     * 临时参数优先级高于 YAML 配置文件中定义的默认值。
+     *
+     * @param key    音效键
+     * @param loc    播放位置
+     * @param volume 临时音量
+     * @param pitch  临时音调
+     */
+    public void play(String key, Location loc, float volume, float pitch) {
+        SoundEffectData base = soundCache.get(key);
+        if (base != null) {
+            float actualVolume = volume * volumeMultiplier;
+            SoundEffectData temp = new SoundEffectData(base.sound, base.name, actualVolume, pitch);
+            playToWorld(loc, temp);
+            logger.debug("在位置 " + loc + " 播放音效: " + key
+                    + " (volume=" + volume + ", pitch=" + pitch + ")");
+        } else if (warnOnMissingKeys) {
+            logger.warn("找不到音效键: " + key);
+        }
+    }
+
+    /**
      * 在半径范围内播放音效
      *
      * @param center 中心位置


### PR DESCRIPTION
## Summary
- allow specifying temporary volume/pitch when playing sounds
- document custom volume/pitch usage in README

## Testing
- `mvn -q -DskipTests install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e596910a483308f716697ecf9cc24