### PR TITLE
Add closeable support for AsyncTaskManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ AsyncTaskManager manager = AsyncTaskManager
         .executor(exec)
         .scheduler(sched) // 可替换为封装 BukkitScheduler 的实现
         .build();
+// 在插件 onDisable() 方法中调用以释放线程资源
+// manager.close();
 ```
 
 若需使用 Bukkit 原生调度器，可将 `BukkitScheduler` 封装为 `ScheduledExecutorService` 后传入 `scheduler()`。

--- a/src/main/java/cn/drcomo/corelib/async/AsyncTaskManager.java
+++ b/src/main/java/cn/drcomo/corelib/async/AsyncTaskManager.java
@@ -15,8 +15,9 @@ import java.util.concurrent.atomic.AtomicInteger;
  * 内部维护普通和定时两种线程池，用于执行和调度异步任务。
  * 所有回调中的异常都会被捕获并记录到提供的 {@link DebugUtil} 实例。
  * </p>
+ * 在插件关闭时应调用 {@link #close()} 以释放线程资源。
  */
-public class AsyncTaskManager {
+public class AsyncTaskManager implements AutoCloseable {
 
     private static final AtomicInteger THREAD_COUNTER = new AtomicInteger(1);
 
@@ -111,6 +112,15 @@ public class AsyncTaskManager {
     public void shutdown() {
         executor.shutdown();
         scheduler.shutdown();
+    }
+
+    /**
+     * 与 {@link #shutdown()} 功能相同，方便 try-with-resources
+     * 或在插件 {@code onDisable()} 中调用。
+     */
+    @Override
+    public void close() {
+        shutdown();
     }
 
     private Runnable wrap(Runnable task) {


### PR DESCRIPTION
## Summary
- implement `AutoCloseable` in `AsyncTaskManager`
- note closing requirement in class Javadoc
- document resource cleanup in README

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687efdeca5dc8330bb15584fa218fe42