### PR TITLE
Add YamlUtil watch management

### DIFF
--- a/DrcomoCoreLib/JavaDocs/config/YamlUtil-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/config/YamlUtil-JavaDoc.md
@@ -174,6 +174,12 @@
     handle.close();
     ```
 
+  * #### `stopAllWatches()`
+
+      * **返回类型:** `void`
+      * **功能描述:** 关闭并清理所有由 `watchConfig` 创建的监听器。通常在插件停用
+        时调用，以避免后台线程泄露。
+
   * #### `getValue(String path, Class<T> type, T defaultValue)`
 
       * **返回类型:** `<T>`

--- a/README.md
+++ b/README.md
@@ -119,9 +119,8 @@ myLogger.info("我的插件已成功加载，并配置好了核心库工具！")
 
     @Override
     public void onDisable() {
-        if (configHandle != null) {
-            configHandle.close();
-        }
+        // 停止所有文件监听器，防止线程泄露
+        myYamlUtil.stopAllWatches();
     }
 }
 ```


### PR DESCRIPTION
## Summary
- keep created ConfigWatchHandle references inside YamlUtil
- auto-register new watchers to that set
- provide `stopAllWatches()` to close them in bulk
- recommend calling `stopAllWatches()` on plugin disable

## Testing
- `java -version`
- ❌ `mvn -q -ntp -DskipTests package` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687efdf719e88330b4df56ed71d35cb6