### PR TITLE
Add session timeout customization

### DIFF
--- a/DrcomoCoreLib/JavaDocs/gui/GUISessionManager-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/gui/GUISessionManager-JavaDoc.md
@@ -8,14 +8,18 @@
 **2. 如何实例化 (Initialization)**
 
   * **核心思想:** 该管理器遵循控制反转原则，构造时需要传入主插件实例、调试工具以及可选的 `MessageService`。它本身不注册事件，事件应由外部绑定。
-  * **构造函数:** `public GUISessionManager(Plugin plugin, DebugUtil debug, MessageService messageService)`
+  * **构造函数 1:** `public GUISessionManager(Plugin plugin, DebugUtil debug, MessageService messageService)`
+  * **构造函数 2:** `public GUISessionManager(Plugin plugin, DebugUtil debug, MessageService messageService, long sessionTimeout)`
   * **代码示例:**
     ```java
     Plugin plugin = this; // 你的插件主类
     DebugUtil logger = new DebugUtil(plugin, DebugUtil.LogLevel.INFO);
     MessageService msgSvc = null; // 如无需要可传入 null
 
+    // 使用默认 5 分钟过期时间
     GUISessionManager manager = new GUISessionManager(plugin, logger, msgSvc);
+    // 或自定义过期时间（毫秒）
+    // GUISessionManager manager = new GUISessionManager(plugin, logger, msgSvc, 10 * 60 * 1000L);
     ```
 
 **3. 公共API方法 (Public API Methods)**
@@ -79,6 +83,12 @@
 
       * **功能描述:** 插件关闭 (`onDisable`) 时同步回收所有仍在会话中的 GUI 物品并返还给玩家；若背包已满则自然掉落。
       * **使用场景:** 保证插件关闭时不会因调度器停止而导致物品丢失。
+
+  * #### `void setSessionTimeout(long sessionTimeout)`
+
+      * **功能描述:** 动态调整会话的过期时间（毫秒）。
+      * **参数说明:**
+          * `sessionTimeout` (`long`): 会话过期的毫秒数。
 
 **4. 注意事项 (Cautions)**
 

--- a/DrcomoCoreLib/README.md
+++ b/DrcomoCoreLib/README.md
@@ -275,6 +275,7 @@ if (coreLib != null) {
     * [查看](./JavaDocs/gui/interfaces/SlotPredicate-JavaDoc.md) (理解定义 **“在哪里生效”** 的条件)
 - **核心逻辑查询 (事件分发)**：[查看](./JavaDocs/gui/GuiActionDispatcher-JavaDoc.md) (用于注册 `ClickAction` 与 `SlotPredicate` 的组合)
 - **关联查询 (会话管理)**：[查看](./JavaDocs/gui/GUISessionManager-JavaDoc.md) (用于打开、关闭、验证玩家的GUI会话)
+- **会话超时设置**：构造 `GUISessionManager` 时可传入自定义过期毫秒数，或稍后调用 `setSessionTimeout(long)` 动态调整。
 - **关联查询 (数据载体)**：[查看](./JavaDocs/gui/ClickContext-JavaDoc.md) (用于在回调中获取点击类型、玩家等上下文信息)
 - **关联查询 (辅助工具)**：[查看](./JavaDocs/gui/GuiManager-JavaDoc.md) (用于安全播放音效、清理光标、检查危险点击等)
 


### PR DESCRIPTION
## Summary
- allow passing custom timeout into `GUISessionManager`
- document constructors and setter for the timeout

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f07e1a36483308c0fd0876b5b0447