### PR TITLE
Add thread customization to AsyncTaskManager

### DIFF
--- a/DrcomoCoreLib/JavaDocs/async/AsyncTaskManager-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/async/AsyncTaskManager-JavaDoc.md
@@ -27,6 +27,13 @@
             .scheduler(sched)
             .build();
 
+    // 仅调节线程数量与名称
+    AsyncTaskManager tuned = AsyncTaskManager
+            .newBuilder(plugin, logger)
+            .poolSize(4)
+            .threadFactory(r -> new Thread(r, "MyPool-%d".formatted(r.hashCode())))
+            .build();
+
     manager.submitAsync(() -> logger.info("run"));
     ```
 

--- a/DrcomoCoreLib/README.md
+++ b/DrcomoCoreLib/README.md
@@ -115,6 +115,13 @@ AsyncTaskManager manager = AsyncTaskManager
         .executor(exec)
         .scheduler(sched) // 可替换为封装 BukkitScheduler 的实现
         .build();
+
+// 快速调整内部线程池
+AsyncTaskManager tuned = AsyncTaskManager
+        .newBuilder(this, myLogger)
+        .poolSize(4)
+        .threadFactory(r -> new Thread(r, "Worker-" + r.hashCode()))
+        .build();
 // 在插件 onDisable() 方法中调用以释放线程资源
 // manager.close();
 ```
@@ -239,7 +246,7 @@ if (coreLib != null) {
 
 
 ### 异步任务管理
-- **功能描述**：管理异步任务执行，支持任务提交、延迟执行、定时调度、批量处理等，内置异常捕获和日志记录。
+- **功能描述**：管理异步任务执行，支持任务提交、延迟执行、定时调度、批量处理等，内置异常捕获和日志记录。通过 Builder 可调整线程池大小及线程工厂。
 - **查询文档**：[查看](./JavaDocs/async/AsyncTaskManager-JavaDoc.md)
 
 


### PR DESCRIPTION
## Summary
- allow specifying pool size and thread factories for AsyncTaskManager
- show builder usage for new options in docs
- document builder options in README

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f07e89a7883309efe4b4f677fb91a