### PR TITLE
Add request method and builder options for HttpUtil

### DIFF
--- a/DrcomoCoreLib/JavaDocs/net/HttpUtil-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/net/HttpUtil-JavaDoc.md
@@ -4,7 +4,7 @@
 
   * **完整路径:** `cn.drcomo.corelib.net.HttpUtil`
   * **核心职责:** 通过 Java 11 `HttpClient` 提供异步的 GET、POST 与文件上传功能。
-    构建器允许配置代理、超时时间以及失败重试次数，并将网络异常记录到 `DebugUtil`。
+    构建器允许配置代理、基础 URI、默认请求头、超时时间以及失败重试次数，并将网络异常记录到 `DebugUtil`。
 
 **2. 如何实例化 (Initialization)**
 
@@ -18,11 +18,16 @@
             .logger(logger)
             .timeout(Duration.ofSeconds(5))
             .retries(2)
+            .baseUri(URI.create("https://api.example.com/"))
+            .defaultHeader("User-Agent", "MyPlugin")
             .build();
     ```
 
 **3. 常用方法 (API)**
 
+  * #### `CompletableFuture<HttpResponse<String>> request(HttpRequest request)`
+
+      * **功能描述:** 直接发送自定义的 HttpRequest 对象，返回完整的响应。
   * #### `CompletableFuture<String> get(String url, Map<String,String> headers)`
 
       * **功能描述:** 以 GET 方式请求指定 URL，返回响应文本。
@@ -46,6 +51,8 @@
 | `retries(int)` | 最大重试次数 |
 | `client(HttpClient)` | 使用自定义 `HttpClient` 实例 |
 | `executor(Executor)` | 自定义执行器用于构建内部 `HttpClient` |
+| `baseUri(URI)` | 设置基础 URI，支持相对路径 |
+| `defaultHeader(String, String)` | 添加默认请求头 |
 
 **自定义 HttpClient 示例**
 
@@ -54,5 +61,6 @@ ExecutorService pool = Executors.newFixedThreadPool(2);
 HttpUtil http = HttpUtil.newBuilder()
         .logger(logger)
         .executor(pool)
+        .defaultHeader("User-Agent", "MyPlugin")
         .build();
 ```

--- a/DrcomoCoreLib/README.md
+++ b/DrcomoCoreLib/README.md
@@ -132,6 +132,8 @@ HttpClient client = HttpClient.newBuilder()
 HttpUtil http = HttpUtil.newBuilder()
         .logger(myLogger)
         .client(client)      // 直接使用自定义 HttpClient
+        .baseUri(URI.create("https://api.example.com/"))
+        .defaultHeader("User-Agent", "MyPlugin")
         .build();
 ```
 
@@ -166,7 +168,7 @@ if (coreLib != null) {
   * `JsonUtil`: 适用于保存或读取 JSON 文件、验证与美化 JSON 字符串。
   * `PlaceholderAPIUtil`: PlaceholderAPI 占位符注册与解析工具。
   * `EconomyProvider`: 经济插件（Vault, PlayerPoints）的统一接口。
-  * `HttpUtil`: 异步 HTTP 请求工具，可配置代理、超时、重试或自定义 HttpClient 和执行器。
+  * `HttpUtil`: 异步 HTTP 请求工具，可配置代理、默认请求头、基础 URI、超时、重试或自定义 HttpClient 和执行器。
   * `ArchiveUtil`: 压缩、解压与日期归档管理工具。
   * `AsyncTaskManager`: 统一管理异步任务与定时调度的工具。
   * `PerformanceUtil`: 获取 TPS、CPU、内存与 GC 数据的性能监控工具。


### PR DESCRIPTION
## Summary
- extend `HttpUtil` with `request(HttpRequest)` returning full `HttpResponse`
- allow builder to set default headers and base URI
- update GET/POST/upload implementations to use the new API
- refresh docs and README examples with new options

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f07ece3fc8330b6fbb3af01647425