### PR TITLE
Add adjustable sound volume multiplier

### DIFF
--- a/DrcomoCoreLib/JavaDocs/sound/SoundManager-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/sound/SoundManager-JavaDoc.md
@@ -25,7 +25,7 @@
         myYamlUtil,
         myLogger,
         soundConfigFileName, // 告诉管理器去哪里找音效配置
-        1.0f,                // 全局音量倍率，1.0f 代表不增不减
+        1.0f,                // 初始全局音量倍率
         true                 // 如果播放一个不存在的音效键，在控制台打印警告
     );
 
@@ -39,6 +39,9 @@
 
     // 最重要的一步：实例化后，必须调用 loadSounds() 来加载配置
     soundManager.loadSounds();
+
+    // 运行时可调整全局音量倍率
+    soundManager.setVolumeMultiplier(1.2f);
 
     myLogger.info("音效管理器已加载 " + soundManager.getCachedSoundCount() + " 个音效。");
     ```
@@ -75,6 +78,13 @@
       * **返回类型:** `Set<String>`
       * **功能描述:** 获取所有已成功加载的音效键的集合。
       * **参数说明:** 无。
+
+  * #### `setVolumeMultiplier(float volumeMultiplier)`
+
+      * **返回类型:** `void`
+      * **功能描述:** 在运行时设置全局音量倍率，后续播放都会应用新的倍率。
+      * **参数说明:**
+          * `volumeMultiplier` (`float`): 新的音量倍率。
 
   * #### `playSound(Player player, String key)`
 

--- a/DrcomoCoreLib/README.md
+++ b/DrcomoCoreLib/README.md
@@ -63,6 +63,8 @@ public class MyAwesomePlugin extends JavaPlugin {
             true            // 找不到音效时警告
         );
         mySoundManager.loadSounds(); // 手动加载音效
+        // 可随时调整全局音量倍率
+        mySoundManager.setVolumeMultiplier(1.2f);
         // 可在需要时自定义音量与音调
         // mySoundManager.play("level_up", player.getLocation(), 0.8f, 1.2f);
 

--- a/src/main/java/cn/drcomo/corelib/sound/SoundManager.java
+++ b/src/main/java/cn/drcomo/corelib/sound/SoundManager.java
@@ -36,7 +36,7 @@ public class SoundManager {
     /** 配置文件名（不含 .yml） */
     public final String configName;
     /** 全局音量倍率，用于统一调节音量 */
-    public final float volumeMultiplier;
+    private float volumeMultiplier;
     /** 是否在找不到音效键时输出警告 */
     public final boolean warnOnMissingKeys;
 
@@ -59,6 +59,15 @@ public class SoundManager {
         this.configName = configName;
         this.volumeMultiplier = volumeMultiplier;
         this.warnOnMissingKeys = warnOnMissingKeys;
+    }
+
+    /**
+     * 设置全局音量倍率。
+     *
+     * @param volumeMultiplier 新的音量倍率
+     */
+    public void setVolumeMultiplier(float volumeMultiplier) {
+        this.volumeMultiplier = volumeMultiplier;
     }
 
     // ===== 加载与重载 =====
@@ -321,10 +330,11 @@ public class SoundManager {
     private void playToWorld(Location loc, SoundEffectData data) {
         World world = loc.getWorld();
         if (world == null) return;
+        float vol = data.volume * volumeMultiplier;
         if (data.sound != null) {
-            world.playSound(loc, data.sound, data.volume, data.pitch);
+            world.playSound(loc, data.sound, vol, data.pitch);
         } else {
-            world.playSound(loc, data.name, data.volume, data.pitch);
+            world.playSound(loc, data.name, vol, data.pitch);
         }
     }
 
@@ -332,10 +342,11 @@ public class SoundManager {
      * 为玩家播放音效
      */
     private void playSoundForPlayer(Player player, Location location, SoundEffectData data) {
+        float vol = data.volume * volumeMultiplier;
         if (data.sound != null) {
-            player.playSound(location, data.sound, data.volume, data.pitch);
+            player.playSound(location, data.sound, vol, data.pitch);
         } else {
-            player.playSound(location, data.name, data.volume, data.pitch);
+            player.playSound(location, data.name, vol, data.pitch);
         }
     }
 
@@ -393,8 +404,7 @@ public class SoundManager {
                 }
             }
 
-            // 应用全局音量倍率
-            volume *= volumeMultiplier;
+
 
             // 尝试将无命名空间且无小数点的名称解析为枚举
             Sound enumSound = null;


### PR DESCRIPTION
## Summary
- allow runtime update for volume multiplier in SoundManager
- multiply current volume multiplier on playback
- document `setVolumeMultiplier` usage
- update README example with new setter

## Testing
- `apt-get update` *(fails: repository signatures invalid)*

------
https://chatgpt.com/codex/tasks/task_e_687f080486948330bdb816edd723f054