### PR TITLE
Add PlayerSessionManager

### DIFF
--- a/DrcomoCoreLib/JavaDocs/session/PlayerSessionManager-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/session/PlayerSessionManager-JavaDoc.md
@@ -1,0 +1,32 @@
+### `PlayerSessionManager.java`
+
+**1. 概述 (Overview)**
+
+  * **完整路径:** `cn.drcomo.corelib.session.PlayerSessionManager`
+  * **核心职责:** 为玩家创建、检索和销毁自定义会话数据，并在超时或玩家离线时自动清理。
+
+**2. 如何实例化 (Initialization)**
+
+  * **核心思想:** 管理器在构造时注入 `Plugin` 与 `DebugUtil`，并自动注册 `PlayerQuitEvent` 监听。
+  * **构造函数 1:** `new PlayerSessionManager(plugin, debug)` 使用默认五分钟超时。
+  * **构造函数 2:** `new PlayerSessionManager(plugin, debug, timeout)` 自定义超时时长（毫秒，<=0 表示永不过期）。
+
+**3. 公共API方法 (Public API Methods)**
+
+  * #### `void createSession(Player player, T data)`
+      * **功能描述:** 为玩家创建或覆盖会话数据。
+  * #### `T getSession(Player player)`
+      * **返回类型:** `T`
+      * **功能描述:** 取得玩家会话数据，不存在或已过期时返回 `null`。
+  * #### `void destroySession(Player player)`
+      * **功能描述:** 主动移除玩家的会话记录。
+  * #### `boolean hasSession(Player player)`
+      * **返回类型:** `boolean`
+      * **功能描述:** 判断玩家是否拥有活跃会话。
+  * #### `void setSessionTimeout(long sessionTimeout)`
+      * **功能描述:** 动态调整会话的全局超时时长。
+
+**4. 注意事项 (Cautions)**
+
+  * 会话超时检查在每次访问或创建时触发，超时<=0则不会自动清理。
+  * 管理器自动监听 `PlayerQuitEvent`，玩家离线会立即移除其会话。

--- a/DrcomoCoreLib/README.md
+++ b/DrcomoCoreLib/README.md
@@ -265,6 +265,7 @@ if (coreLib != null) {
 - **核心逻辑查询 (事件分发)**：[查看](./JavaDocs/gui/GuiActionDispatcher-JavaDoc.md) (用于注册 `ClickAction` 与 `SlotPredicate` 的组合)
 - **关联查询 (会话管理)**：[查看](./JavaDocs/gui/GUISessionManager-JavaDoc.md) (用于打开、关闭、验证玩家的GUI会话)
 - **会话超时设置**：构造 `GUISessionManager` 时可传入自定义过期毫秒数，或稍后调用 `setSessionTimeout(long)` 动态调整。
+- **通用玩家会话**：[查看](./JavaDocs/session/PlayerSessionManager-JavaDoc.md) (创建、获取或销毁与玩家相关的临时数据，退出或超时后自动清理)
 - **关联查询 (数据载体)**：[查看](./JavaDocs/gui/ClickContext-JavaDoc.md) (用于在回调中获取点击类型、玩家等上下文信息)
 - **关联查询 (辅助工具)**：[查看](./JavaDocs/gui/GuiManager-JavaDoc.md) (用于安全播放音效、清理光标、检查危险点击等)
 

--- a/src/main/java/cn/drcomo/corelib/session/PlayerSessionManager.java
+++ b/src/main/java/cn/drcomo/corelib/session/PlayerSessionManager.java
@@ -1,0 +1,147 @@
+package cn.drcomo.corelib.session;
+
+import cn.drcomo.corelib.util.DebugUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.plugin.Plugin;
+
+import java.util.*;
+
+/**
+ * 通用的玩家会话管理器。
+ *
+ * <p>通过泛型形式保存玩家会话数据，可设置超时并在玩家离线时自动清理。</p>
+ * <p>无需自行注册事件，构造时会自动向插件管理器注册监听器。</p>
+ */
+public class PlayerSessionManager<T> implements Listener {
+
+    /** 默认会话过期时间：5 分钟 */
+    private static final long DEFAULT_SESSION_TIMEOUT = 5 * 60 * 1000L;
+
+    private final Plugin plugin;
+    private final DebugUtil debug;
+    private final Map<UUID, Session<T>> sessions = new HashMap<>();
+    private long sessionTimeout = DEFAULT_SESSION_TIMEOUT;
+
+    /**
+     * 构造函数，使用默认 5 分钟超时。
+     *
+     * @param plugin 插件实例
+     * @param debug  日志工具
+     */
+    public PlayerSessionManager(Plugin plugin, DebugUtil debug) {
+        this(plugin, debug, DEFAULT_SESSION_TIMEOUT);
+    }
+
+    /**
+     * 构造函数，可自定义会话过期时间。
+     *
+     * @param plugin         插件实例
+     * @param debug          日志工具
+     * @param sessionTimeout 会话超时时间（毫秒），<=0 表示不过期
+     */
+    public PlayerSessionManager(Plugin plugin, DebugUtil debug, long sessionTimeout) {
+        this.plugin = plugin;
+        this.debug = debug;
+        this.sessionTimeout = sessionTimeout;
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    /**
+     * 创建或替换玩家的会话数据。
+     *
+     * @param player 玩家
+     * @param data   会话数据
+     */
+    public void createSession(Player player, T data) {
+        if (player == null) {
+            debug.warn("createSession player null");
+            return;
+        }
+        cleanExpired();
+        sessions.put(player.getUniqueId(), new Session<>(data, sessionTimeout));
+    }
+
+    /**
+     * 获取玩家会话数据。
+     *
+     * @param player 玩家
+     * @return 会话数据，若不存在或已过期则返回 null
+     */
+    public T getSession(Player player) {
+        if (player == null) return null;
+        cleanExpired();
+        Session<T> s = sessions.get(player.getUniqueId());
+        return s == null ? null : s.data;
+    }
+
+    /**
+     * 销毁玩家会话。
+     *
+     * @param player 玩家
+     */
+    public void destroySession(Player player) {
+        if (player == null) return;
+        sessions.remove(player.getUniqueId());
+    }
+
+    /**
+     * 判断玩家是否存在活跃会话。
+     *
+     * @param player 玩家
+     * @return true 表示存在
+     */
+    public boolean hasSession(Player player) {
+        if (player == null) return false;
+        cleanExpired();
+        return sessions.containsKey(player.getUniqueId());
+    }
+
+    /**
+     * 调整全局会话超时设置。
+     *
+     * @param sessionTimeout 超时时间，<=0 表示禁用过期检查
+     */
+    public void setSessionTimeout(long sessionTimeout) {
+        this.sessionTimeout = sessionTimeout;
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        destroySession(event.getPlayer());
+    }
+
+    // ================== 私有助手 ==================
+    private void cleanExpired() {
+        if (sessionTimeout <= 0) return;
+        List<UUID> expired = new ArrayList<>();
+        long now = System.currentTimeMillis();
+        for (Map.Entry<UUID, Session<T>> e : sessions.entrySet()) {
+            if (e.getValue().isExpired(now)) {
+                expired.add(e.getKey());
+            }
+        }
+        for (UUID id : expired) {
+            sessions.remove(id);
+        }
+    }
+
+    private static class Session<T> {
+        final T data;
+        final long createTime;
+        final long timeout;
+
+        Session(T data, long timeout) {
+            this.data = data;
+            this.timeout = timeout;
+            this.createTime = System.currentTimeMillis();
+        }
+
+        boolean isExpired(long now) {
+            return timeout > 0 && now - createTime > timeout;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `PlayerSessionManager` for generic player session handling
- document class under JavaDocs
- mention new session manager in README

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_688461f75b1c833095729fc24c76b91b