### PR TITLE
Add SkullUtil for custom player skulls

### DIFF
--- a/DrcomoCoreLib/JavaDocs/util/SkullUtil-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/util/SkullUtil-JavaDoc.md
@@ -1,0 +1,32 @@
+### `SkullUtil.java`
+
+**1. 概述 (Overview)**
+
+  * **完整路径:** `cn.drcomo.corelib.util.SkullUtil`
+  * **核心职责:** 根据 URL 或 base64 字符串生成带自定义纹理的玩家頭顱 `ItemStack`。内部封装 `GameProfile`、`SkullMeta` 等实现细节，并通过 `DebugUtil` 输出异常日志。
+
+**2. 如何实例化 (Initialization)**
+
+  * **核心思想:** 该类无状态，构造时只需注入 `DebugUtil` 以便记录日志，可在多个模块中复用。
+  * **代码示例:**
+    ```java
+    DebugUtil logger = new DebugUtil(this, DebugUtil.LogLevel.INFO);
+    SkullUtil skullUtil = new SkullUtil(logger);
+    ```
+
+**3. 公共API方法 (Public API Methods)**
+
+  * #### `ItemStack fromUrl(String url)`
+      * **功能描述:** 传入纹理 URL，返回带有该纹理的玩家头颅物品。
+      * **参数说明:** `url` (`String`): 形如 `http://textures.minecraft.net/texture/...` 的地址。
+
+  * #### `ItemStack fromBase64(String base64)`
+      * **功能描述:** 传入已编码的纹理 Base64 字符串，返回玩家头颅物品。
+
+**4. 创建自定义头像示例 (Usage Example)**
+
+```java
+String url = "http://textures.minecraft.net/texture/<texture-id>";
+ItemStack skull = skullUtil.fromUrl(url);
+player.getInventory().addItem(skull);
+```

--- a/src/main/java/cn/drcomo/corelib/util/SkullUtil.java
+++ b/src/main/java/cn/drcomo/corelib/util/SkullUtil.java
@@ -1,0 +1,66 @@
+package cn.drcomo.corelib.util;
+
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.properties.Property;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
+
+import java.lang.reflect.Field;
+import java.util.Base64;
+import java.util.UUID;
+
+/**
+ * 玩家头像工具类，用于生成带自定义纹理的头颅物品。
+ */
+public class SkullUtil {
+
+    private final DebugUtil logger;
+
+    /**
+     * 构造 SkullUtil。
+     *
+     * @param logger DebugUtil 实例
+     */
+    public SkullUtil(DebugUtil logger) {
+        this.logger = logger;
+    }
+
+    /**
+     * 根据纹理 URL 创建玩家头颅。
+     *
+     * @param url 纹理地址
+     * @return 带自定义纹理的 ItemStack
+     */
+    public ItemStack fromUrl(String url) {
+        if (url == null || url.isEmpty()) {
+            return new ItemStack(Material.PLAYER_HEAD);
+        }
+        String json = "{\"textures\":{\"SKIN\":{\"url\":\"" + url + "\"}}}";
+        String base64 = Base64.getEncoder().encodeToString(json.getBytes());
+        return fromBase64(base64);
+    }
+
+    /**
+     * 根据 Base64 字符串创建玩家头颅。
+     *
+     * @param base64 纹理 Base64
+     * @return 带自定义纹理的 ItemStack
+     */
+    public ItemStack fromBase64(String base64) {
+        try {
+            ItemStack skull = new ItemStack(Material.PLAYER_HEAD);
+            SkullMeta meta = (SkullMeta) skull.getItemMeta();
+            GameProfile profile = new GameProfile(UUID.randomUUID(), null);
+            profile.getProperties().put("textures", new Property("textures", base64));
+            Field field = meta.getClass().getDeclaredField("profile");
+            field.setAccessible(true);
+            field.set(meta, profile);
+            skull.setItemMeta(meta);
+            return skull;
+        } catch (Exception e) {
+            logger.error("生成自定义头像失败", e);
+            return new ItemStack(Material.PLAYER_HEAD);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `SkullUtil` with `DebugUtil` injection
- support creating skull items from url or base64 texture
- document how to use it in `SkullUtil-JavaDoc`

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68846865fbcc833099d52501cf3db884