### PR TITLE
Use itemStackToNBT in toRawString

### DIFF
--- a/DrcomoCoreLib/JavaDocs/nbt/NBTUtil-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/nbt/NBTUtil-JavaDoc.md
@@ -199,6 +199,7 @@
           * 返回值为标准 SNBT（Stringified Named Binary Tag）格式，类似 JSON，但字段顺序、类型与 Minecraft NBT 规范一致。
           * 例如：`{id:"minecraft:diamond_sword",Count:1b,tag:{display:{Name:"\"神器\""},CustomModelData:1234}}`
           * 若物品无 NBT 或异常，返回 "{}"。
+          * 输出字符串始终包含 `id` 与 `Count` 字段，可直接传入 `fromRawString` 还原物品。
       * **典型用途:**
           * 适合直接打印日志、人工比对、与 NBTExplorer/NBT Exporter 等工具输出对照。
           * 输出结果可直接作为 `fromRawString` 的输入，恢复原物品。

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M9</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
         </plugins>
         <resources>
             <resource>
@@ -153,5 +161,12 @@
             <version>1.5.21</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.9.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
 </project>

--- a/src/main/java/cn/drcomo/corelib/nbt/NBTUtil.java
+++ b/src/main/java/cn/drcomo/corelib/nbt/NBTUtil.java
@@ -427,8 +427,8 @@ public class NBTUtil {
     /**
      * 获取 ItemStack 的完整 NBT 数据并序列化为字符串（SNBT 格式）。
      * <p>
-     * 该方法将使用 NBT-API 的 {@code toString()} 实现，返回类似 JSON 的 SNBT 字符串，
-     * 便于日志打印、问题排查与人工比对。
+     * 该方法内部通过 {@link NBT#itemStackToNBT(ItemStack)} 获取物品的 NBT
+     * 数据，再调用其 {@code toString()} 返回标准 SNBT 字符串，便于日志打印、问题排查与人工比对。
      * <pre>
      * String raw = nbtUtil.toRawString(item);
      * plugin.getLogger().info(raw);
@@ -441,10 +441,10 @@ public class NBTUtil {
     public String toRawString(ItemStack item) {
         if (item == null) return "{}";
         try {
-            final String[] result = {"{}"};
-            // 只读访问，无需克隆
-            NBT.get(item, (ReadableItemNBT nbt) -> result[0] = nbt.toString());
-            return result[0];
+            // NBT.itemStackToNBT 会返回包含 id 与 Count 的完整 NBT
+            ItemStack clone = item.clone();
+            ReadWriteNBT nbt = NBT.itemStackToNBT(clone);
+            return nbt.toString();
         } catch (Exception ex) {
             logger.log(LogLevel.DEBUG, "toRawString 异常: " + ex.getMessage());
             return "{}";

--- a/src/test/java/cn/drcomo/corelib/nbt/NBTUtilTest.java
+++ b/src/test/java/cn/drcomo/corelib/nbt/NBTUtilTest.java
@@ -1,0 +1,63 @@
+package cn.drcomo.corelib.nbt;
+
+import cn.drcomo.corelib.util.DebugUtil;
+import cn.drcomo.corelib.util.DebugUtil.LogLevel;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Basic tests for {@link NBTUtil#toRawString(ItemStack)} and
+ * {@link NBTUtil#fromRawString(String)}.
+ */
+public class NBTUtilTest {
+
+    private final NbtKeyHandler handler = new NbtKeyHandler() {
+        @Override
+        public boolean isValidKey(String fullKey) {
+            return true;
+        }
+        @Override
+        public String addPrefix(String key) {
+            return key;
+        }
+        @Override
+        public String removePrefix(String fullKey) {
+            return fullKey;
+        }
+    };
+
+    private final DebugUtil logger = new DebugUtil(new org.bukkit.plugin.Plugin() {
+        private final java.util.logging.Logger l = java.util.logging.Logger.getLogger("dummy");
+        @Override public java.util.logging.Logger getLogger() { return l; }
+        // the remaining methods are irrelevant for this test and left empty
+        @Override public org.bukkit.plugin.PluginDescriptionFile getDescription() { return null; }
+        @Override public void onDisable() {}
+        @Override public void onEnable() {}
+        @Override public void onLoad() {}
+        @Override public boolean isNaggable() { return false; }
+        @Override public void setNaggable(boolean canNag) {}
+        @Override public org.bukkit.configuration.file.FileConfiguration getConfig() { return null; }
+        @Override public void reloadConfig() {}
+        @Override public void saveConfig() {}
+        @Override public void saveDefaultConfig() {}
+        @Override public void saveResource(String resourcePath, boolean replace) {}
+        @Override public java.io.File getDataFolder() { return null; }
+        @Override public org.bukkit.plugin.PluginLoader getPluginLoader() { return null; }
+        @Override public org.bukkit.Server getServer() { return null; }
+        @Override public boolean isEnabled() { return true; }
+        @Override public boolean isLoaded() { return true; }
+        @Override public void reloadDataFolder() {}
+    }, LogLevel.DEBUG);
+
+    @Test
+    public void roundTripShouldKeepNbt() throws Exception {
+        NBTUtil util = new NBTUtil(handler, logger);
+        ItemStack item = new ItemStack(Material.DIAMOND, 2);
+        String raw = util.toRawString(item);
+        ItemStack clone = util.fromRawString(raw);
+        assertEquals(util.toRawString(item), util.toRawString(clone));
+    }
+}


### PR DESCRIPTION
## Summary
- update `NBTUtil.toRawString` to use `NBT.itemStackToNBT`
- document new behaviour in `NBTUtil-JavaDoc`
- add junit test for round-trip with `fromRawString`
- configure surefire and junit-jupiter in `pom.xml`

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6884ba2d2e8083308291c0f16b37fdf1