### PR TITLE
feat: 提供通用外层符号替换工具

### DIFF
--- a/DrcomoCoreLib/JavaDocs/hook/placeholder/PlaceholderAPIUtil-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/hook/placeholder/PlaceholderAPIUtil-JavaDoc.md
@@ -119,3 +119,29 @@
         });
         ```
 
+* #### `convertOuterCharsToPercent(String input, char openChar, char closeChar)`
+
+    * **返回类型:** `String`
+    * **功能描述:** 将最外层指定符号对替换为 `%`，内部层级的同符号保持不变。
+    * **参数说明:**
+        * `input` (`String`): 待处理字符串。
+        * `openChar` (`char`): 左符号，例如 `{`。
+        * `closeChar` (`char`): 右符号，例如 `}`。
+    * **使用示例:**
+        ```java
+        String r = PlaceholderAPIUtil.convertOuterCharsToPercent("[a[b]c]", '[', ']');
+        // r -> "%a[b]c%"
+        ```
+
+* #### `convertOuterBracesToPercent(String input)`
+
+    * **返回类型:** `String`
+    * **功能描述:** 仅针对花括号的便捷封装，等同于 `convertOuterCharsToPercent(input, '{', '}')`。
+    * **参数说明:**
+        * `input` (`String`): 待处理字符串。
+    * **使用示例:**
+        ```java
+        String r = PlaceholderAPIUtil.convertOuterBracesToPercent("{a{b}c}");
+        // r -> "%a{b}c%"
+        ```
+

--- a/src/main/java/cn/drcomo/corelib/hook/placeholder/PlaceholderAPIUtil.java
+++ b/src/main/java/cn/drcomo/corelib/hook/placeholder/PlaceholderAPIUtil.java
@@ -20,7 +20,8 @@ import java.util.function.Function;
  *    2. 暴露 {@link #register(String, BiFunction)} 及 {@link #registerSpecial(String, Function)} 供子插件注册自定义占位符；
  *    3. 提供 {@link #parse(Player, String)} 递归解析工具；
  *    4. 提供 {@link #parse(Player, String, Map)} 带自定义占位符预替换的解析工具；
- *    5. 提供 {@link #splitArgs(String)} 多参数拆分工具。<br><br>
+ *    5. 提供 {@link #splitArgs(String)} 多参数拆分工具；
+ *    6. 提供 {@link #convertOuterCharsToPercent(String, char, char)} 外层符号转百分号工具。<br><br>
  *
  *  ◎ 使用方式<br>
  *    1. onEnable() 中调用 {@link #initialize(Plugin, String)};<br>
@@ -170,6 +171,52 @@ public class PlaceholderAPIUtil {
             return new String[0];
         }
         return rawArgs.split("_", -1);
+    }
+
+    /**
+     * 将最外层指定符号对替换为 "%"，内部层级的同符号保持不变。
+     *
+     * @param input     待处理的原始字符串
+     * @param openChar  外层左符号，如 '{'
+     * @param closeChar 外层右符号，如 '}'
+     * @return 处理后的字符串；当输入为 null 或空串时返回空串；若首尾不存在成对符号或结构不匹配，则直接返回原字符串
+     */
+    public static String convertOuterCharsToPercent(String input, char openChar, char closeChar) {
+        if (input == null || input.isEmpty()) {
+            return "";
+        }
+        if (input.charAt(0) != openChar || input.charAt(input.length() - 1) != closeChar) {
+            return input;
+        }
+        int depth = 0;
+        for (int i = 0; i < input.length(); i++) {
+            char c = input.charAt(i);
+            if (c == openChar) {
+                depth++;
+            } else if (c == closeChar) {
+                depth--;
+                if (depth == 0 && i != input.length() - 1) {
+                    return input;
+                }
+                if (depth < 0) {
+                    return input;
+                }
+            }
+        }
+        if (depth != 0) {
+            return input;
+        }
+        return '%' + input.substring(1, input.length() - 1) + '%';
+    }
+
+    /**
+     * 将最外层的 "{" 与 "}" 替换为 "%"，内部的花括号保持不变。
+     *
+     * @param input 待处理的原始字符串
+     * @return 处理后的字符串；当输入为 null 或空串时返回空串；若首尾不存在成对花括号或结构不匹配，则直接返回原字符串
+     */
+    public static String convertOuterBracesToPercent(String input) {
+        return convertOuterCharsToPercent(input, '{', '}');
     }
 
     // === 示例模板 Javadoc Markdown 操作文档里必须有示例 ===


### PR DESCRIPTION
## Summary
- 引入 `convertOuterCharsToPercent` 允许将任意符号对包裹的最外层替换为 `%`
- 提供 `convertOuterBracesToPercent` 作为花括号便捷封装，并更新对应 API 文档

## Testing
- `mvn -q test` *(失败：Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: The following artifacts could not be resolved: org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 (absent): Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688dd37e17148330845206f7c97cf5c0