### PR TITLE
优化半径音效计算

### DIFF
--- a/src/main/java/cn/drcomo/corelib/sound/SoundManager.java
+++ b/src/main/java/cn/drcomo/corelib/sound/SoundManager.java
@@ -206,7 +206,8 @@ public class SoundManager {
     public void playSoundInRadius(Location center, String key, double radius) {
         SoundEffectData data = soundCache.get(key);
         if (data != null) {
-            playToPlayersInRadius(center, data, radius);
+            double radiusSquared = radius * radius; // 预先计算半径平方
+            playToPlayersInRadius(center, data, radiusSquared);
             logger.debug("在 " + center + " 半径 " + radius + " 范围内播放音效: " + key);
         } else if (warnOnMissingKeys) {
             logger.warn("找不到音效键: " + key);
@@ -237,7 +238,8 @@ public class SoundManager {
     public void playSoundFromStringInRadius(Location center, String soundString, double radius) {
         SoundEffectData data = parseSoundString(soundString);
         if (data != null) {
-            playToPlayersInRadius(center, data, radius);
+            double radiusSquared = radius * radius; // 预先计算半径平方
+            playToPlayersInRadius(center, data, radiusSquared);
             logger.debug("在 " + center + " 半径 " + radius + " 范围内播放音效字符串: " + soundString);
         } else if (warnOnMissingKeys) {
             logger.warn("音效字符串格式无效: " + soundString);
@@ -354,11 +356,11 @@ public class SoundManager {
     /**
      * 在指定半径范围内向所有玩家播放音效
      */
-    private void playToPlayersInRadius(Location center, SoundEffectData data, double radius) {
+    private void playToPlayersInRadius(Location center, SoundEffectData data, double radiusSquared) {
         World world = center.getWorld();
         if (world == null) return;
         for (Player player : world.getPlayers()) {
-            if (player.getLocation().distance(center) <= radius) {
+            if (player.getLocation().distanceSquared(center) <= radiusSquared) {
                 playSoundForPlayer(player, center, data);
             }
         }


### PR DESCRIPTION
## Summary
- 使用距离平方比较方式，避免在播放半径音效时重复开平方计算
- 调整半径播放方法，预先计算半径平方并传递，减少重复乘法

## Testing
- `mvn -q -e test` *(失败：Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68920d17c33c8330b80bf420fb19a783