### PR TITLE
使用迭代器清理过期 GUI 会话

### DIFF
--- a/src/main/java/cn/drcomo/corelib/gui/GUISessionManager.java
+++ b/src/main/java/cn/drcomo/corelib/gui/GUISessionManager.java
@@ -10,6 +10,7 @@ import cn.drcomo.corelib.util.DebugUtil;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -246,15 +247,13 @@ public class GUISessionManager {
     }
 
     private void cleanExpiredSessions() {
-        List<Player> expired = new ArrayList<>();
-        for (Map.Entry<Player, GUISession> e : sessions.entrySet()) {
-            if (e.getValue().isExpired()) {
-                expired.add(e.getKey());
-            }
-        }
-        for (Player p : expired) {
-            GUISession s = sessions.get(p);
-            if (s != null) {
+        Iterator<Map.Entry<Player, GUISession>> it = sessions.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<Player, GUISession> entry = it.next();
+            if (entry.getValue().isExpired()) {
+                Player p = entry.getKey();
+                GUISession s = entry.getValue();
+                it.remove();
                 safeClose(p, s);
             }
         }


### PR DESCRIPTION
## Summary
- 使用迭代器遍历会话并即时清理过期项，避免重复遍历

## Testing
- `mvn -q -e test` *(失败：网络不可达)*

------
https://chatgpt.com/codex/tasks/task_e_68920d261a488330951d34f871315d9d