### PR TITLE
使用迭代器清理过期会话

### DIFF
--- a/src/main/java/cn/drcomo/corelib/gui/session/PlayerSessionManager.java
+++ b/src/main/java/cn/drcomo/corelib/gui/session/PlayerSessionManager.java
@@ -117,15 +117,13 @@ public class PlayerSessionManager<T> implements Listener {
     // ================== 私有助手 ==================
     private void cleanExpired() {
         if (sessionTimeout <= 0) return;
-        List<UUID> expired = new ArrayList<>();
         long now = System.currentTimeMillis();
-        for (Map.Entry<UUID, Session<T>> e : sessions.entrySet()) {
+        Iterator<Map.Entry<UUID, Session<T>>> it = sessions.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<UUID, Session<T>> e = it.next();
             if (e.getValue().isExpired(now)) {
-                expired.add(e.getKey());
+                it.remove();
             }
-        }
-        for (UUID id : expired) {
-            sessions.remove(id);
         }
     }
 


### PR DESCRIPTION
## 摘要
- 改用迭代器遍历与移除过期会话，避免额外的列表临时存储。

## 测试
- `mvn -q test`（插件无法从中央仓库下载，测试未运行）


------
https://chatgpt.com/codex/tasks/task_e_68920d2b8ce88330b793958ed0e52a1a