### PR TITLE
优化自定义占位符解析逻辑

### DIFF
--- a/src/main/java/cn/drcomo/corelib/message/MessageService.java
+++ b/src/main/java/cn/drcomo/corelib/message/MessageService.java
@@ -501,9 +501,16 @@ public class MessageService {
 
         // —— 1. 自定义占位符 ——
         if (custom != null && !custom.isEmpty()) {
-            for (var e : custom.entrySet()) {
-                result = result.replace(prefix + e.getKey() + suffix, e.getValue());
+            Pattern pattern = Pattern.compile(prefix + "(?<key>[^" + suffix + "]+)" + suffix);
+            Matcher matcher = pattern.matcher(result);
+            StringBuffer sb = new StringBuffer();
+            while (matcher.find()) {
+                String key = matcher.group("key");
+                String value = custom.getOrDefault(key, matcher.group(0));
+                matcher.appendReplacement(sb, Matcher.quoteReplacement(value));
             }
+            matcher.appendTail(sb);
+            result = sb.toString();
         }
 
         // —— 2. 内部 {key[:args]} ——


### PR DESCRIPTION
## 摘要
- 使用正则与 Matcher 单次扫描处理自定义占位符
- 保持内部占位符、额外正则与 PlaceholderAPI 解析顺序不变

## 测试
- `mvn -q test` *(因依赖下载失败导致未通过：Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68920d524b608330a6fe2ed1ec190bcd