### PR TITLE
feat: 提供线程池访问接口

### DIFF
--- a/src/main/java/cn/drcomo/corelib/async/AsyncTaskManager.java
+++ b/src/main/java/cn/drcomo/corelib/async/AsyncTaskManager.java
@@ -49,6 +49,24 @@ public class AsyncTaskManager implements AutoCloseable {
     //================ public API =================
 
     /**
+     * 获取内部执行线程池。
+     *
+     * @return ExecutorService 实例
+     */
+    public ExecutorService getExecutor() {
+        return executor;
+    }
+
+    /**
+     * 获取内部调度线程池。
+     *
+     * @return ScheduledExecutorService 实例
+     */
+    public ScheduledExecutorService getScheduler() {
+        return scheduler;
+    }
+
+    /**
      * 提交一个异步任务。
      *
      * @param task 任务


### PR DESCRIPTION
## Summary
- 新增 `getExecutor()` 方法，便于外部获取执行线程池
- 新增 `getScheduler()` 方法，允许访问调度线程池

## Testing
- `mvn -q test` *(因缺失依赖 `maven-resources-plugin:3.3.1` 未能执行)*

------
https://chatgpt.com/codex/tasks/task_e_689357254ff08330ba3ae7ac750c0e7d