### PR TITLE
feat: 暴露异步线程池

### DIFF
--- a/src/main/java/cn/drcomo/corelib/async/AsyncTaskManager.java
+++ b/src/main/java/cn/drcomo/corelib/async/AsyncTaskManager.java
@@ -115,6 +115,24 @@ public class AsyncTaskManager implements AutoCloseable {
     }
 
     /**
+     * 获取内部执行线程池。
+     *
+     * @return ExecutorService 实例
+     */
+    public ExecutorService getExecutor() {
+        return executor;
+    }
+
+    /**
+     * 获取内部调度线程池。
+     *
+     * @return ScheduledExecutorService 实例
+     */
+    public ScheduledExecutorService getScheduler() {
+        return scheduler;
+    }
+
+    /**
      * 关闭线程池，停止接受新任务。
      */
     public void shutdown() {


### PR DESCRIPTION
## Summary
- 新增 `getExecutor` 与 `getScheduler` 方法以公开内部线程池

## Testing
- `mvn -q test` *(失败：网络不可达)*

------
https://chatgpt.com/codex/tasks/task_e_689357254ff08330ba3ae7ac750c0e7d