### PR TITLE
feat(async): 增加任务优先级与异步接口

### DIFF
--- a/DrcomoCoreLib/JavaDocs/async/AsyncTaskManager-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/async/AsyncTaskManager-JavaDoc.md
@@ -3,7 +3,7 @@
 **1. 概述 (Overview)**
 
   * **完整路径:** `cn.drcomo.corelib.async.AsyncTaskManager`
-  * **核心职责:** 提供基于线程池的异步任务提交與調度能力，並在執行過程中自動捕獲並記錄例外。
+  * **核心职责:** 提供基于线程池的异步任务提交与调度能力，支持带优先级的任务队列，并在执行过程中自动捕获并记录异常。
 
 **2. 如何实例化 (Initialization)**
 
@@ -42,6 +42,21 @@
 
 **3. 公共API方法 (Public API Methods)**
 
+  * #### `<T> Future<T> submitWithPriority(Supplier<T> supplier, TaskPriority priority)`
+      * **返回类型:** `Future<T>`
+      * **功能描述:** 将 `Supplier` 提交到带优先级的队列，高优先级任务会先执行。
+  * #### `Future<?> runWithPriority(Runnable task, TaskPriority priority)`
+      * **返回类型:** `Future<?>`
+      * **功能描述:** 在带优先级的队列中运行一个 `Runnable` 任务。
+  * #### `TaskQueueStatus getQueueStatus()`
+      * **返回类型:** `TaskQueueStatus`
+      * **功能描述:** 获取当前优先级任务队列中各优先级的任务数量。
+  * #### `<T> CompletableFuture<T> supplyAsync(Supplier<T> supplier)`
+      * **返回类型:** `CompletableFuture<T>`
+      * **功能描述:** 使用 `CompletableFuture` 异步执行 `Supplier`，便于链式调用。
+  * #### `CompletableFuture<Void> runAsync(Runnable task)`
+      * **返回类型:** `CompletableFuture<Void>`
+      * **功能描述:** 使用 `CompletableFuture` 异步执行 `Runnable`。
   * #### `Future<?> submitAsync(Runnable task)`
       * **返回类型:** `Future<?>`
       * **功能描述:** 在内部线程池中异步执行一个 `Runnable`。

--- a/DrcomoCoreLib/JavaDocs/async/TaskPriority-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/async/TaskPriority-JavaDoc.md
@@ -1,0 +1,26 @@
+### `TaskPriority.java`
+
+**1. 概述 (Overview)**
+
+  * **完整路径:** `cn.drcomo.corelib.async.TaskPriority`
+  * **核心职责:** 定义异步任务的优先级，数值越小优先级越高。
+
+**2. 枚举值说明 (Enum Constants)**
+
+  * `HIGH` - 高优先级任务，优先执行。
+  * `NORMAL` - 普通优先级任务。
+  * `LOW` - 低优先级任务，最后执行。
+
+**3. 公共API方法 (Public API Methods)**
+
+  * #### `getLevel()`
+      * **返回类型:** `int`
+      * **功能描述:** 获取内部优先级数值，数值越小表示优先级越高。
+
+**4. 典型用法 (Typical Usage)**
+
+  * 配合 `AsyncTaskManager` 提交带优先级的任务：
+    ```java
+    asyncTaskManager.runWithPriority(() -> logger.info("高优先级任务"), TaskPriority.HIGH);
+    ```
+

--- a/DrcomoCoreLib/JavaDocs/async/TaskQueueStatus-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/async/TaskQueueStatus-JavaDoc.md
@@ -1,0 +1,40 @@
+### `TaskQueueStatus.java`
+
+**1. 概述 (Overview)**
+
+  * **完整路径:** `cn.drcomo.corelib.async.TaskQueueStatus`
+  * **核心职责:** 描述优先级任务队列当前的各优先级任务数量，可用于监控与调试。
+
+**2. 如何实例化 (Initialization)**
+
+  * **核心思想:** 通常通过 `AsyncTaskManager#getQueueStatus()` 获取实例，开发者一般无需手动创建。
+  * **构造函数:** `public TaskQueueStatus(int highCount, int normalCount, int lowCount)`
+  * **代码示例:**
+    ```java
+    TaskQueueStatus status = asyncTaskManager.getQueueStatus();
+    logger.info("高优先级: " + status.getHighCount());
+    ```
+
+**3. 公共API方法 (Public API Methods)**
+
+  * #### `getHighCount()`
+      * **返回类型:** `int`
+      * **功能描述:** 获取高优先级任务数量。
+  * #### `getNormalCount()`
+      * **返回类型:** `int`
+      * **功能描述:** 获取普通优先级任务数量。
+  * #### `getLowCount()`
+      * **返回类型:** `int`
+      * **功能描述:** 获取低优先级任务数量。
+  * #### `getTotal()`
+      * **返回类型:** `int`
+      * **功能描述:** 获取队列中的任务总数。
+
+**4. 典型用法 (Typical Usage)**
+
+  * 调用 `AsyncTaskManager#getQueueStatus()` 监控优先级队列负载：
+    ```java
+    TaskQueueStatus status = asyncTaskManager.getQueueStatus();
+    logger.debug(status.toString());
+    ```
+

--- a/DrcomoCoreLib/README.md
+++ b/DrcomoCoreLib/README.md
@@ -327,6 +327,8 @@ if (coreLib != null) {
 - **功能描述**：管理异步任务执行，支持任务提交、延迟执行、定时调度、批量处理等，内置异常捕获和日志记录。通过 Builder 可调整线程池大小及线程工厂。
 - **包类路径**：`cn.drcomo.corelib.async.AsyncTaskManager`
 - **查询文档**：[查看](./JavaDocs/async/AsyncTaskManager-JavaDoc.md)
+- **关联查询 1**：[查看](./JavaDocs/async/TaskPriority-JavaDoc.md)（任务优先级枚举）
+- **关联查询 2**：[查看](./JavaDocs/async/TaskQueueStatus-JavaDoc.md)（队列状态对象）
 
 
 ### 性能监控

--- a/src/main/java/cn/drcomo/corelib/async/TaskPriority.java
+++ b/src/main/java/cn/drcomo/corelib/async/TaskPriority.java
@@ -1,0 +1,28 @@
+package cn.drcomo.corelib.async;
+
+/**
+ * 任务优先级枚举，数值越小优先级越高。
+ */
+public enum TaskPriority {
+    /** 高优先级任务，优先执行 */
+    HIGH(0),
+    /** 普通优先级任务 */
+    NORMAL(1),
+    /** 低优先级任务，最后执行 */
+    LOW(2);
+
+    private final int level;
+
+    TaskPriority(int level) {
+        this.level = level;
+    }
+
+    /**
+     * 获取内部优先级数值。
+     *
+     * @return 数值，越小越高
+     */
+    public int getLevel() {
+        return level;
+    }
+}

--- a/src/main/java/cn/drcomo/corelib/async/TaskQueueStatus.java
+++ b/src/main/java/cn/drcomo/corelib/async/TaskQueueStatus.java
@@ -1,0 +1,61 @@
+package cn.drcomo.corelib.async;
+
+/**
+ * 任务队列当前状态。
+ */
+public class TaskQueueStatus {
+
+    private final int highCount;
+    private final int normalCount;
+    private final int lowCount;
+
+    /**
+     * 构造队列状态。
+     *
+     * @param highCount   高优先级任务数量
+     * @param normalCount 普通优先级任务数量
+     * @param lowCount    低优先级任务数量
+     */
+    public TaskQueueStatus(int highCount, int normalCount, int lowCount) {
+        this.highCount = highCount;
+        this.normalCount = normalCount;
+        this.lowCount = lowCount;
+    }
+
+    /**
+     * 获取高优先级任务数量。
+     */
+    public int getHighCount() {
+        return highCount;
+    }
+
+    /**
+     * 获取普通优先级任务数量。
+     */
+    public int getNormalCount() {
+        return normalCount;
+    }
+
+    /**
+     * 获取低优先级任务数量。
+     */
+    public int getLowCount() {
+        return lowCount;
+    }
+
+    /**
+     * 获取队列总任务数。
+     */
+    public int getTotal() {
+        return highCount + normalCount + lowCount;
+    }
+
+    @Override
+    public String toString() {
+        return "TaskQueueStatus{" +
+                "高优先级=" + highCount +
+                ", 普通优先级=" + normalCount +
+                ", 低优先级=" + lowCount +
+                '}';
+    }
+}

--- a/src/test/java/cn/drcomo/corelib/async/PriorityTaskExample.java
+++ b/src/test/java/cn/drcomo/corelib/async/PriorityTaskExample.java
@@ -1,0 +1,37 @@
+package cn.drcomo.corelib.async;
+
+import cn.drcomo.corelib.util.DebugUtil;
+import org.bukkit.plugin.Plugin;
+
+import java.lang.reflect.Proxy;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+/**
+ * 优先级任务队列使用示例。
+ */
+public class PriorityTaskExample {
+
+    public static void main(String[] args) throws Exception {
+        Plugin plugin = (Plugin) Proxy.newProxyInstance(
+                Plugin.class.getClassLoader(),
+                new Class[]{Plugin.class},
+                (proxy, method, methodArgs) -> {
+                    if ("getName".equals(method.getName())) {
+                        return "ExamplePlugin";
+                    } else if ("getLogger".equals(method.getName())) {
+                        return Logger.getLogger("ExamplePlugin");
+                    } else if (method.getReturnType().equals(boolean.class)) {
+                        return false;
+                    }
+                    return null;
+                });
+        DebugUtil logger = new DebugUtil(plugin, DebugUtil.LogLevel.DEBUG);
+        try (AsyncTaskManager manager = new AsyncTaskManager(plugin, logger)) {
+            manager.runWithPriority(() -> logger.info("低优先级任务"), TaskPriority.LOW);
+            manager.runWithPriority(() -> logger.info("高优先级任务"), TaskPriority.HIGH);
+            // 等待任务完成
+            TimeUnit.MILLISECONDS.sleep(500);
+        }
+    }
+}

--- a/src/test/java/cn/drcomo/corelib/async/PriorityTaskManagerTest.java
+++ b/src/test/java/cn/drcomo/corelib/async/PriorityTaskManagerTest.java
@@ -1,0 +1,59 @@
+package cn.drcomo.corelib.async;
+
+import cn.drcomo.corelib.util.DebugUtil;
+import org.bukkit.plugin.Plugin;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * 测试优先级任务执行顺序。
+ */
+public class PriorityTaskManagerTest {
+
+    private Plugin createPlugin() {
+        return (Plugin) Proxy.newProxyInstance(
+                Plugin.class.getClassLoader(),
+                new Class[]{Plugin.class},
+                (proxy, method, args) -> {
+                    if ("getName".equals(method.getName())) {
+                        return "TestPlugin";
+                    } else if ("getLogger".equals(method.getName())) {
+                        return Logger.getLogger("TestPlugin");
+                    } else if (method.getReturnType().equals(boolean.class)) {
+                        return false;
+                    }
+                    return null;
+                });
+    }
+
+    @Test
+    void priorityOrder() throws Exception {
+        Plugin plugin = createPlugin();
+        DebugUtil logger = new DebugUtil(plugin, DebugUtil.LogLevel.ERROR);
+        try (AsyncTaskManager manager = new AsyncTaskManager(plugin, logger)) {
+            List<String> order = Collections.synchronizedList(new ArrayList<>());
+            CountDownLatch latch = new CountDownLatch(3);
+
+            manager.runWithPriority(() -> { order.add("low"); latch.countDown(); }, TaskPriority.LOW);
+            manager.runWithPriority(() -> { order.add("high"); latch.countDown(); }, TaskPriority.HIGH);
+            manager.runWithPriority(() -> { order.add("normal"); latch.countDown(); }, TaskPriority.NORMAL);
+
+            latch.await(2, TimeUnit.SECONDS);
+            assertEquals(List.of("high", "normal", "low"), order);
+            assertEquals(0, manager.getQueueStatus().getTotal());
+
+            // 验证 CompletableFuture 接口
+            assertEquals(1, manager.supplyAsync(() -> 1).get().intValue());
+            manager.runAsync(() -> order.add("async")).get();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 引入 `TaskPriority` 枚举和 `TaskQueueStatus`，描述任务优先级与队列状态
- `AsyncTaskManager` 支持优先级任务提交并提供 `supplyAsync`、`runAsync`
- 编写示例与单元测试演示高优先级任务先执行
- 新增相关 Markdown API 文档并在 `DrcomoCoreLib/README.md` 中补充引用

## Testing
- `mvn -q test` *(依赖解析失败：Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68947aad39b88330a1819f02a87933b0