### PR TITLE
feat: 增加数据库统计与连接池状态

### DIFF
--- a/DrcomoCoreLib/JavaDocs/database/ConnectionPoolStatus-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/database/ConnectionPoolStatus-JavaDoc.md
@@ -1,0 +1,28 @@
+### `ConnectionPoolStatus.java`
+
+**1. 概述 (Overview)**
+
+  * **完整路径:** `cn.drcomo.corelib.database.ConnectionPoolStatus`
+  * **核心职责:** 封装 HikariCP 连接池的当前状态，包括总连接数、活跃连接数和空闲连接数。
+
+**2. 如何实例化 (Initialization)**
+
+  * **核心思想:** 通常由 `SQLiteDB#getPoolStatus()` 创建并返回，调用方一般只需读取其中的数据。如需手动构造，可使用其公共构造函数。
+  * **构造函数:** `public ConnectionPoolStatus(int totalConnections, int activeConnections, int idleConnections)`
+  * **代码示例:**
+    ```java
+    ConnectionPoolStatus status = db.getPoolStatus();
+    int idle = status.getIdleConnections();
+    ```
+
+**3. 公共API方法 (Public API Methods)**
+
+  * #### `getTotalConnections()`
+      * **返回类型:** `int`
+      * **功能描述:** 获取连接池中总连接数。
+  * #### `getActiveConnections()`
+      * **返回类型:** `int`
+      * **功能描述:** 获取当前被占用的连接数量。
+  * #### `getIdleConnections()`
+      * **返回类型:** `int`
+      * **功能描述:** 获取当前空闲的连接数量。

--- a/DrcomoCoreLib/JavaDocs/database/DatabaseMetrics-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/database/DatabaseMetrics-JavaDoc.md
@@ -1,0 +1,31 @@
+### `DatabaseMetrics.java`
+
+**1. 概述 (Overview)**
+
+  * **完整路径:** `cn.drcomo.corelib.database.DatabaseMetrics`
+  * **核心职责:** 记录 SQLite 数据库执行统计信息，包含连接借出次数、语句执行总数及累计耗时。
+
+**2. 如何实例化 (Initialization)**
+
+  * **核心思想:** 由 `SQLiteDB#getMetrics()` 生成并返回，开发者通常直接消费此对象的只读数据。必要时也可通过公共构造函数手动创建。
+  * **构造函数:** `public DatabaseMetrics(long borrowedConnections, long executedStatements, long totalExecutionTimeMillis)`
+  * **代码示例:**
+    ```java
+    DatabaseMetrics metrics = db.getMetrics();
+    long avg = metrics.getAverageExecutionTimeMillis();
+    ```
+
+**3. 公共API方法 (Public API Methods)**
+
+  * #### `getBorrowedConnections()`
+      * **返回类型:** `long`
+      * **功能描述:** 获取连接被借出的累计次数。
+  * #### `getExecutedStatements()`
+      * **返回类型:** `long`
+      * **功能描述:** 获取执行过的 SQL 语句数量。
+  * #### `getTotalExecutionTimeMillis()`
+      * **返回类型:** `long`
+      * **功能描述:** 获取所有语句执行的累计耗时（毫秒）。
+  * #### `getAverageExecutionTimeMillis()`
+      * **返回类型:** `long`
+      * **功能描述:** 计算并返回单条语句的平均执行耗时（毫秒）。

--- a/DrcomoCoreLib/JavaDocs/database/SQLiteDB-JavaDoc.md
+++ b/DrcomoCoreLib/JavaDocs/database/SQLiteDB-JavaDoc.md
@@ -3,7 +3,7 @@
 **1. 概述 (Overview)**
 
   * **完整路径:** `cn.drcomo.corelib.database.SQLiteDB`
-  * **核心职责:** 管理 SQLite 连接、初始化表结构，并提供最基础的增删改查以及事务执行能力。自 1.1 起内部集成 HikariCP 连接池，保证多线程环境下安全获取连接。它遵循零硬编码和控制反转原则，由调用方传入数据库路径和初始化脚本。
+  * **核心职责:** 管理 SQLite 连接、初始化表结构，并提供增删改查、事务及批量操作能力。自 1.1 起内部集成 HikariCP 连接池，并支持查询连接池状态与执行统计，保证多线程环境下安全获取连接。它遵循零硬编码和控制反转原则，由调用方传入数据库路径和初始化脚本。
 
 **2. 如何实例化 (Initialization)**
 
@@ -43,6 +43,26 @@
 
       * **返回类型:** `void`
       * **功能描述:** 按顺序读取构造时提供的 SQL 脚本，以分号为界执行每条语句，用于建表或升级数据库结构。
+      * **参数说明:** 无
+
+  * #### `getPoolStatus()`
+
+      * **返回类型:** `ConnectionPoolStatus`
+      * **功能描述:** 获取当前连接池的总连接数、活跃连接数与空闲连接数。
+      * **参数说明:** 无
+      * **关联文档:** [查看](./ConnectionPoolStatus-JavaDoc.md)
+
+  * #### `getMetrics()`
+
+      * **返回类型:** `DatabaseMetrics`
+      * **功能描述:** 返回数据库连接借出次数与语句执行耗时等统计信息。
+      * **参数说明:** 无
+      * **关联文档:** [查看](./DatabaseMetrics-JavaDoc.md)
+
+  * #### `isConnectionValid()`
+
+      * **返回类型:** `boolean`
+      * **功能描述:** 检查当前数据源连接是否可用。
       * **参数说明:** 无
 
   * #### `executeUpdate(String sql, Object... params)`
@@ -104,6 +124,29 @@
 
       * **返回类型:** `CompletableFuture<Void>`
       * **功能描述:** 异步执行事务逻辑。
+
+  * #### `batchUpdate(String sql, List<Object[]> paramsList)`
+
+      * **返回类型:** `CompletableFuture<int[]>`
+      * **功能描述:** 异步执行同一 SQL 的批量更新。
+      * **参数说明:**
+          * `sql` (`String`): 更新语句模板。
+          * `paramsList` (`List<Object[]>`): 每条更新所需的参数数组。
+
+  * #### `batchInsert(String table, List<Map<String, Object>> dataList)`
+
+      * **返回类型:** `CompletableFuture<Void>`
+      * **功能描述:** 根据键值集合批量插入多行数据。
+      * **参数说明:**
+          * `table` (`String`): 目标表名。
+          * `dataList` (`List<Map<String, Object>>`): 每行数据的键值对集合。
+
+  * #### `<T> executeInTransaction(Function<Connection, T> op)`
+
+      * **返回类型:** `CompletableFuture<T>`
+      * **功能描述:** 在单个事务中执行操作并返回结果。
+      * **参数说明:**
+          * `op` (`Function<Connection, T>`): 需要在事务中执行的逻辑。
 
 **4. 内部接口 (Inner Interfaces)**
 

--- a/DrcomoCoreLib/README.md
+++ b/DrcomoCoreLib/README.md
@@ -394,4 +394,6 @@ if (coreLib != null) {
 ### 数据库操作 (SQLite)
 - **功能描述**：连接管理 SQLite 数据库，初始化表结构，执行增删改查（CRUD）、事务处理。内置 HikariCP 连接池并提供异步接口，适合并发环境。
 - **包类路径**：`cn.drcomo.corelib.database.SQLiteDB`
-- **查询文档**：[查看](./JavaDocs/database)
+- **查询文档 1（核心 API）**：[查看](./JavaDocs/database/SQLiteDB-JavaDoc.md)
+- **查询文档 2（连接池状态）**：[查看](./JavaDocs/database/ConnectionPoolStatus-JavaDoc.md)
+- **查询文档 3（执行统计）**：[查看](./JavaDocs/database/DatabaseMetrics-JavaDoc.md)

--- a/src/main/java/cn/drcomo/corelib/database/ConnectionPoolStatus.java
+++ b/src/main/java/cn/drcomo/corelib/database/ConnectionPoolStatus.java
@@ -1,0 +1,28 @@
+package cn.drcomo.corelib.database;
+
+/**
+ * 连接池状态信息。
+ */
+public class ConnectionPoolStatus {
+    private final int totalConnections;
+    private final int activeConnections;
+    private final int idleConnections;
+
+    public ConnectionPoolStatus(int totalConnections, int activeConnections, int idleConnections) {
+        this.totalConnections = totalConnections;
+        this.activeConnections = activeConnections;
+        this.idleConnections = idleConnections;
+    }
+
+    public int getTotalConnections() {
+        return totalConnections;
+    }
+
+    public int getActiveConnections() {
+        return activeConnections;
+    }
+
+    public int getIdleConnections() {
+        return idleConnections;
+    }
+}

--- a/src/main/java/cn/drcomo/corelib/database/DatabaseMetrics.java
+++ b/src/main/java/cn/drcomo/corelib/database/DatabaseMetrics.java
@@ -1,0 +1,37 @@
+package cn.drcomo.corelib.database;
+
+/**
+ * 数据库运行统计信息。
+ */
+public class DatabaseMetrics {
+    private final long borrowedConnections;
+    private final long executedStatements;
+    private final long totalExecutionTimeMillis;
+
+    public DatabaseMetrics(long borrowedConnections, long executedStatements, long totalExecutionTimeMillis) {
+        this.borrowedConnections = borrowedConnections;
+        this.executedStatements = executedStatements;
+        this.totalExecutionTimeMillis = totalExecutionTimeMillis;
+    }
+
+    public long getBorrowedConnections() {
+        return borrowedConnections;
+    }
+
+    public long getExecutedStatements() {
+        return executedStatements;
+    }
+
+    public long getTotalExecutionTimeMillis() {
+        return totalExecutionTimeMillis;
+    }
+
+    /**
+     * 获取平均单条语句执行耗时。
+     *
+     * @return 平均耗时，单位毫秒
+     */
+    public long getAverageExecutionTimeMillis() {
+        return executedStatements == 0 ? 0 : totalExecutionTimeMillis / executedStatements;
+    }
+}


### PR DESCRIPTION
## Summary
- 添加 `ConnectionPoolStatus` 与 `DatabaseMetrics` 数据类，用于暴露连接池状态和执行统计
- 扩展 `SQLiteDB` 支持连接池状态查询、数据库指标获取及连接有效性检测
- 新增批量更新、批量插入与事务执行方法，并记录执行耗时与次数
- 补充 `SQLiteDB`、`ConnectionPoolStatus` 与 `DatabaseMetrics` 的 API 文档，并在 `DrcomoCoreLib/README.md` 中添加引用

## Testing
- `mvn -q test` *(失败：Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact ... Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68947ab6d3d88330ab146c4f8dc7da4b