### PR TITLE
feat: add async sound loading

### DIFF
--- a/DrcomoCoreLib/README.md
+++ b/DrcomoCoreLib/README.md
@@ -67,6 +67,10 @@ public class MyAwesomePlugin extends JavaPlugin {
             true            // 找不到音效时警告
         );
         mySoundManager.loadSounds(); // 手动加载音效
+        // 也可异步加载，解析完成后会在主线程更新缓存以避免线程安全问题
+        // AsyncTaskManager asyncManager = new AsyncTaskManager(this, myLogger);
+        // mySoundManager.loadSoundsAsync(asyncManager)
+        //     .thenRun(() -> myLogger.info("音效异步加载完成"));
         // 可随时调整全局音量倍率
         mySoundManager.setVolumeMultiplier(1.2f);
         // 可在需要时自定义音量与音调


### PR DESCRIPTION
## Summary
- 新增 `loadSoundsAsync` 支持使用 `AsyncTaskManager` 异步解析音效配置，并在主线程刷新缓存
- `reloadSounds` 改为调用异步加载并返回 `CompletableFuture`，可用于回调通知
- 补充文档说明异步加载示例与线程安全注意事项

## Testing
- `mvn -q -e -DskipTests package` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6899e9c10d0c83308e64fdb5407182ce