### PR TITLE
feat: 占位符工具支持并发注册

### DIFF
--- a/src/main/java/cn/drcomo/corelib/hook/placeholder/PlaceholderAPIUtil.java
+++ b/src/main/java/cn/drcomo/corelib/hook/placeholder/PlaceholderAPIUtil.java
@@ -6,8 +6,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -29,6 +29,8 @@ import java.util.function.Function;
  *       在 resolver 内部可通过 {@link #splitArgs(String)} 拆分多参数;<br>
  *    3. 在文本中使用 `%<identifier>_<key>_<arg1>_<arg2>…%` 或先用 `{key}` 自定义占位符;<br>
  *    4. 解析时调用 {@link #parse(Player, String)} 或 {@link #parse(Player, String, Map)}。<br>
+ * <br>
+ *  ⚠️ 占位符注册可在异步线程调用，但解析仍需在主线程执行。<br>
  * ======================================================================
  */
 public class PlaceholderAPIUtil {
@@ -37,7 +39,7 @@ public class PlaceholderAPIUtil {
     private static final int MAX_PARSE_ITERATIONS = 10;
 
     private final Plugin plugin;
-    private final Map<String, BiFunction<Player, String, String>> handlers = new HashMap<>();
+    private final Map<String, BiFunction<Player, String, String>> handlers = new ConcurrentHashMap<>();
     private final String identifier;
     private final PlaceholderExpansion expansion;
     private final String authors;

--- a/src/test/java/cn/drcomo/corelib/hook/placeholder/PlaceholderAPIUtilConcurrentTest.java
+++ b/src/test/java/cn/drcomo/corelib/hook/placeholder/PlaceholderAPIUtilConcurrentTest.java
@@ -1,0 +1,49 @@
+package cn.drcomo.corelib.hook.placeholder;
+
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.concurrent.*;
+import java.util.function.BiFunction;
+
+/**
+ * 并发注册占位符的简单测试。
+ */
+public class PlaceholderAPIUtilConcurrentTest {
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void concurrentRegister() throws Exception {
+        // 使用 Unsafe 分配对象以绕过构造函数
+        Field f = Unsafe.class.getDeclaredField("theUnsafe");
+        f.setAccessible(true);
+        Unsafe unsafe = (Unsafe) f.get(null);
+        PlaceholderAPIUtil util = (PlaceholderAPIUtil) unsafe.allocateInstance(PlaceholderAPIUtil.class);
+
+        // 初始化 handlers 为并发映射
+        Field handlersField = PlaceholderAPIUtil.class.getDeclaredField("handlers");
+        handlersField.setAccessible(true);
+        Map<String, BiFunction<Player, String, String>> handlers = new ConcurrentHashMap<>();
+        handlersField.set(util, handlers);
+
+        int threadCount = 20;
+        ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        for (int i = 0; i < threadCount; i++) {
+            final int idx = i;
+            pool.execute(() -> {
+                util.register("k" + idx, (p, r) -> String.valueOf(idx));
+                latch.countDown();
+            });
+        }
+        latch.await(3, TimeUnit.SECONDS);
+        pool.shutdownNow();
+        // 验证所有占位符均成功注册
+        Assertions.assertEquals(threadCount, handlers.size());
+    }
+}


### PR DESCRIPTION
## Summary
- 使用 `ConcurrentHashMap` 维护占位符处理器，允许异步线程安全注册
- 类注释补充说明注册可异步执行、解析需在主线程完成
- 添加并发注册的简单单元测试

## Testing
- `mvn -q test` *(失败：Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6899e9cbf2b883309be7eef259933576